### PR TITLE
Add option to change persistNotification settings through plugin admi…

### DIFF
--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -97,6 +97,7 @@ class OneSignal_Admin {
       'send_welcome_notification',
       'notification_on_post',
       'notification_on_post_from_plugin',
+      'persistNotification',
       'prompt_customize_enable',
       'prompt_showcredit',
       'notifyButton_enable',

--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -98,6 +98,7 @@ class OneSignal_Admin {
       'notification_on_post',
       'notification_on_post_from_plugin',
       'persistNotification',
+      'showNotificationIconFromPostThumbnail',
       'prompt_customize_enable',
       'prompt_showcredit',
       'notifyButton_enable',
@@ -252,6 +253,18 @@ class OneSignal_Admin {
         'contents' => array("en" => $notif_content)
       );
       
+      if ($onesignal_wp_settings['showNotificationIconFromPostThumbnail'] == "1") {
+        // get the icon image from wordpress if it exists
+        $post_thumbnail_id = get_post_thumbnail_id( $post->ID );
+        $thumbnail_array = wp_get_attachment_image_src($post_thumbnail_id, array( 80, 80 ), true);
+        if (!empty($thumbnail_array)) {
+          $thumbnail = $thumbnail_array[0];
+          // set the icon image for both chrome and firefox-1
+          $fields['chrome_web_icon'] = $thumbnail;
+          $fields['firefox_icon'] = $thumbnail;
+        }
+      }
+
       $ch = curl_init();
       curl_setopt($ch, CURLOPT_URL, "https://onesignal.com/api/v1/notifications");
       curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/json',

--- a/onesignal-public.php
+++ b/onesignal-public.php
@@ -160,6 +160,10 @@ class OneSignal_Public {
         if (@$onesignal_wp_settings["safari_web_id"]) {
           echo "oneSignal_options['safari_web_id'] = \"" . $onesignal_wp_settings["safari_web_id"] . "\";\n";
         }
+        
+        if ($onesignal_wp_settings["persistNotification"] == "0") {
+          echo "oneSignal_options['persistNotification'] = false;\n";
+        }
 
 
         if ($onesignal_wp_settings["subdomain"] != "" || $onesignal_wp_settings["use_modal_prompt"] == "1") {

--- a/onesignal-settings.php
+++ b/onesignal-settings.php
@@ -22,6 +22,7 @@ class OneSignal {
                   'default_url' => "",
                   'app_rest_api_key' => "",
                   'safari_web_id' => "",
+                  'persistNotification' => true,
                   'prompt_customize_enable' => 'CALCULATE_SPECIAL_VALUE',
                   'prompt_action_message' => "",
                   'prompt_example_notification_title_desktop' => "",

--- a/onesignal-settings.php
+++ b/onesignal-settings.php
@@ -23,6 +23,7 @@ class OneSignal {
                   'app_rest_api_key' => "",
                   'safari_web_id' => "",
                   'persistNotification' => true,
+                  'showNotificationIconFromPostThumbnail' => false,
                   'prompt_customize_enable' => 'CALCULATE_SPECIAL_VALUE',
                   'prompt_action_message' => "",
                   'prompt_example_notification_title_desktop' => "",

--- a/views/config.php
+++ b/views/config.php
@@ -888,6 +888,20 @@ if (array_key_exists('app_id', $_POST)) {
             </div>
           </div>
         </div>
+        <div class="ui dividing header">
+          <i class="desktop icon"></i>
+          <div class="content">
+            Other Notification Settings
+          </div>
+        </div>
+        <div class="ui borderless shadowless segment">
+          <div class="field">
+            <div class="ui toggle checkbox">
+              <input type="checkbox" name="persistNotification" value="true" <?php if ($onesignal_wp_settings['persistNotification']) { echo "checked"; } ?>>
+              <label>Persist notifications<i class="tiny circular help icon link" role="popup" data-title="Persist Notifications" data-content="If checked, when a notifcation is sent, do not automatically dismiss it (supported on Chrome Desktop v47+)" data-variation="wide"></i></label>
+            </div>
+          </div>
+        </div>
         <button class="ui large teal button" type="submit">Save</button>
         <div class="ui error message">
         </div>

--- a/views/config.php
+++ b/views/config.php
@@ -902,6 +902,14 @@ if (array_key_exists('app_id', $_POST)) {
             </div>
           </div>
         </div>
+        <div class="ui borderless shadowless segment">
+          <div class="field">
+            <div class="ui toggle checkbox">
+              <input type="checkbox" name="showNotificationIconFromPostThumbnail" value="true" <?php if ($onesignal_wp_settings['showNotificationIconFromPostThumbnail']) { echo "checked"; } ?>>
+              <label>Show icon image from post thumbnail<i class="tiny circular help icon link" role="popup" data-title="Show icon image from post thumbnail" data-content="If checked, when a notifcation is sent link the post icon in the notification.  Chrome and Firefox Desktop supported." data-variation="wide"></i></label>
+            </div>
+          </div>
+        </div>
         <button class="ui large teal button" type="submit">Save</button>
         <div class="ui error message">
         </div>


### PR DESCRIPTION
Feature addition for #6 

Added code to allow setting persistNotification through the wordpress plugin admin page.

By default, option is set to the default behavior (no persistNotification option set on OneSignal.init())

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/one-signal/onesignal-wordpress-plugin/7)
<!-- Reviewable:end -->
