### PR TITLE
Add option to send post icon images with notifications

### DIFF
--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -97,6 +97,7 @@ class OneSignal_Admin {
       'send_welcome_notification',
       'notification_on_post',
       'notification_on_post_from_plugin',
+      'showNotificationIconFromPostThumbnail',
       'prompt_customize_enable',
       'prompt_showcredit',
       'notifyButton_enable',
@@ -251,6 +252,18 @@ class OneSignal_Admin {
         'contents' => array("en" => $notif_content)
       );
       
+      if ($onesignal_wp_settings['showNotificationIconFromPostThumbnail'] == "1") {
+        // get the icon image from wordpress if it exists
+        $post_thumbnail_id = get_post_thumbnail_id( $post->ID );
+        $thumbnail_array = wp_get_attachment_image_src($post_thumbnail_id, array( 80, 80 ), true);
+        if (!empty($thumbnail_array)) {
+          $thumbnail = $thumbnail_array[0];
+          // set the icon image for both chrome and firefox-1
+          $fields['chrome_web_icon'] = $thumbnail;
+          $fields['firefox_icon'] = $thumbnail;
+        }
+      }
+
       $ch = curl_init();
       curl_setopt($ch, CURLOPT_URL, "https://onesignal.com/api/v1/notifications");
       curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/json',

--- a/onesignal-settings.php
+++ b/onesignal-settings.php
@@ -22,6 +22,7 @@ class OneSignal {
                   'default_url' => "",
                   'app_rest_api_key' => "",
                   'safari_web_id' => "",
+                  'showNotificationIconFromPostThumbnail' => false,
                   'prompt_customize_enable' => 'CALCULATE_SPECIAL_VALUE',
                   'prompt_action_message' => "",
                   'prompt_example_notification_title_desktop' => "",

--- a/views/config.php
+++ b/views/config.php
@@ -888,6 +888,20 @@ if (array_key_exists('app_id', $_POST)) {
             </div>
           </div>
         </div>
+        <div class="ui dividing header">
+          <i class="desktop icon"></i>
+          <div class="content">
+            Other Notification Settings
+          </div>
+        </div>
+        <div class="ui borderless shadowless segment">
+          <div class="field">
+            <div class="ui toggle checkbox">
+              <input type="checkbox" name="showNotificationIconFromPostThumbnail" value="true" <?php if ($onesignal_wp_settings['showNotificationIconFromPostThumbnail']) { echo "checked"; } ?>>
+              <label>Show icon image from post thumbnail<i class="tiny circular help icon link" role="popup" data-title="Show icon image from post thumbnail" data-content="If checked, when a notifcation is sent link the post icon in the notification.  Chrome and Firefox Desktop supported." data-variation="wide"></i></label>
+            </div>
+          </div>
+        </div>
         <button class="ui large teal button" type="submit">Save</button>
         <div class="ui error message">
         </div>


### PR DESCRIPTION
Adds an option in the plugin admin panel to add the post's icon image to the notification.

Works for both Firefox and Chrome desktop.

References issue #8

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/one-signal/onesignal-wordpress-plugin/9)
<!-- Reviewable:end -->
