### PR TITLE
Add option to change persistNotification settings through plugin admi…

### DIFF
--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -97,6 +97,7 @@ class OneSignal_Admin {
       'send_welcome_notification',
       'notification_on_post',
       'notification_on_post_from_plugin',
+      'persistNotification',
       'prompt_customize_enable',
       'prompt_showcredit',
       'notifyButton_enable',

--- a/onesignal-public.php
+++ b/onesignal-public.php
@@ -160,6 +160,10 @@ class OneSignal_Public {
         if (@$onesignal_wp_settings["safari_web_id"]) {
           echo "oneSignal_options['safari_web_id'] = \"" . $onesignal_wp_settings["safari_web_id"] . "\";\n";
         }
+        
+        if ($onesignal_wp_settings["persistNotification"] == "0") {
+          echo "oneSignal_options['persistNotification'] = false;\n";
+        }
 
 
         if ($onesignal_wp_settings["subdomain"] != "" || $onesignal_wp_settings["use_modal_prompt"] == "1") {

--- a/onesignal-settings.php
+++ b/onesignal-settings.php
@@ -22,6 +22,7 @@ class OneSignal {
                   'default_url' => "",
                   'app_rest_api_key' => "",
                   'safari_web_id' => "",
+                  'persistNotification' => true,
                   'prompt_customize_enable' => 'CALCULATE_SPECIAL_VALUE',
                   'prompt_action_message' => "",
                   'prompt_example_notification_title_desktop' => "",

--- a/views/config.php
+++ b/views/config.php
@@ -888,6 +888,20 @@ if (array_key_exists('app_id', $_POST)) {
             </div>
           </div>
         </div>
+        <div class="ui dividing header">
+          <i class="desktop icon"></i>
+          <div class="content">
+            Other Notification Settings
+          </div>
+        </div>
+        <div class="ui borderless shadowless segment">
+          <div class="field">
+            <div class="ui toggle checkbox">
+              <input type="checkbox" name="persistNotification" value="true" <?php if ($onesignal_wp_settings['persistNotification']) { echo "checked"; } ?>>
+              <label>Persist notifications<i class="tiny circular help icon link" role="popup" data-title="Persist Notifications" data-content="If checked, when a notifcation is sent, do not automatically dismiss it (supported on Chrome Desktop v47+)" data-variation="wide"></i></label>
+            </div>
+          </div>
+        </div>
         <button class="ui large teal button" type="submit">Save</button>
         <div class="ui error message">
         </div>


### PR DESCRIPTION
References issue #6 

Adds an option to allow setting persistNotification through the wordpress plugin admin page.

By default, option is set to the default behavior (no persistNotification option set on OneSignal.init())

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/one-signal/onesignal-wordpress-plugin/10)
<!-- Reviewable:end -->
