### PR TITLE
Add filter for included_segments to support notification segmentation

### DIFF
--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -123,6 +123,7 @@ class OneSignal_Admin {
       'welcome_notification_title',
       'welcome_notification_message',
       'welcome_notification_url',
+      'includedSegments',
       'notifyButton_size',
       'notifyButton_theme',
       'notifyButton_position',
@@ -245,14 +246,16 @@ class OneSignal_Admin {
         $site_title = html_entity_decode(get_bloginfo( 'name' ), ENT_HTML401 | ENT_QUOTES, 'UTF-8');
       }
       
-      $included_segments = array();
-
-      if (has_filter('onesignal_send_notification_included_segments')) {
-        $included_segments = apply_filters('onesignal_send_notification_included_segments', $new_status, $old_status, $post);
+      if (isset($onesignal_wp_settings['includedSegments'])) {
+        $included_segments = array_filter(explode(',', $onesignal_wp_settings['includedSegments']));
       }
 
       if (empty($included_segments)) {
         $included_segments = array('All');
+      }
+
+      if (has_filter('onesignal_send_notification_included_segments')) {
+        $included_segments = apply_filters('onesignal_send_notification_included_segments', $new_status, $old_status, $post);
       }
 
       $fields = array(

--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -270,7 +270,7 @@ class OneSignal_Admin {
       }
 
       if (has_filter('onesignal_send_notification_included_segments')) {
-        $included_segments = apply_filters('onesignal_send_notification_included_segments', $new_status, $old_status, $post);
+        $included_segments = apply_filters('onesignal_send_notification_included_segments', $included_segments, $new_status, $old_status, $post);
       }
 
       $fields = array(

--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -213,13 +213,25 @@ class OneSignal_Admin {
   }
   
   public static function send_notification_on_wp_post($new_status, $old_status, $post) {
-    debug('Calling send_notification_on_wp_post(', $new_status, $old_status, $post);
-    if (empty( $post ) || $new_status !== "publish") {
+    if (has_filter('onesignal_send_notification_pre_send_check')) {
+      // don't send a notification on an empty post, ever
+      if (empty( $post )) {
         return;
-    }
+      }
 
-    if ($post->post_type == 'page') {
-      return;
+      $send_notification = apply_filters('onesignal_send_notification_pre_send_check', $new_status, $old_status, $post);
+      if(isset($send_notification) && !$send_notification) {
+        return;
+      }
+    }
+    else {
+      if (empty( $post ) || $new_status !== "publish") {
+          return;
+      }
+
+      if ($post->post_type == 'page') {
+        return;
+      }
     }
     
     $onesignal_wp_settings = OneSignal::get_onesignal_settings();

--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -213,13 +213,16 @@ class OneSignal_Admin {
   }
   
   public static function send_notification_on_wp_post($new_status, $old_status, $post) {
+    // apply the notification_pre_send_check filter if it is defined.
     if (has_filter('onesignal_send_notification_pre_send_check')) {
       // don't send a notification on an empty post, ever
       if (empty( $post )) {
         return;
       }
 
-      $send_notification = apply_filters('onesignal_send_notification_pre_send_check', $new_status, $old_status, $post);
+      // default to send unless overriden by filter
+      $send_notification = true;
+      $send_notification = apply_filters('onesignal_send_notification_pre_send_check', $send_notification, $new_status, $old_status, $post);
       if(isset($send_notification) && !$send_notification) {
         return;
       }

--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -245,10 +245,20 @@ class OneSignal_Admin {
         $site_title = html_entity_decode(get_bloginfo( 'name' ), ENT_HTML401 | ENT_QUOTES, 'UTF-8');
       }
       
+      $included_segments = array();
+
+      if (has_filter('onesignal_send_notification_included_segments')) {
+        $included_segments = apply_filters('onesignal_send_notification_included_segments', $new_status, $old_status, $post);
+      }
+
+      if (empty($included_segments)) {
+        $included_segments = array('All');
+      }
+
       $fields = array(
         'app_id' => $onesignal_wp_settings['app_id'],
         'headings' => array("en" => $site_title),
-        'included_segments' => array('All'),
+        'included_segments' => $included_segments,
         'isAnyWeb' => true,
         'url' => get_permalink($post->ID),
         'contents' => array("en" => $notif_content)

--- a/onesignal-settings.php
+++ b/onesignal-settings.php
@@ -24,6 +24,7 @@ class OneSignal {
                   'safari_web_id' => "",
                   'showNotificationIconFromPostThumbnail' => false,
                   'chrome_auto_dismiss_notifications' => false,
+                  'includedSegments' => "",
                   'prompt_customize_enable' => 'CALCULATE_SPECIAL_VALUE',
                   'prompt_action_message' => "",
                   'prompt_example_notification_title_desktop' => "",

--- a/views/config.php
+++ b/views/config.php
@@ -908,6 +908,12 @@ if (array_key_exists('app_id', $_POST)) {
             </div>
           </div>
         </div>
+        <div class="ui borderless shadowless segment">
+          <div class="field">
+            <label>Included Segments<i class="tiny circular help icon link" role="popup" data-title="Included Segments" data-content="What segments you want all notifications to be sent to.  If you want to send to more than one segment, separate them with a comma.  This can also be customized programattically in your theme by adding a custom filter for 'onesignal_send_notification_included_segments'" data-variation="wide"></i></label>
+            <input type="text" placeholder="Defaults to All if blank" name="includedSegments" value="<?php echo @$onesignal_wp_settings['includedSegments']; ?>">
+          </div>
+        </div>
         <button class="ui large teal button" type="submit">Save</button>
         <div class="ui error message">
         </div>


### PR DESCRIPTION
References issue #11 

Add a new wordpress filter called 'onesignal_send_notification_included_segments'.

If this filter is defined in the user's theme/plugin, it will allow the customization of the included_segments value to be whatever the theme returns.

Sample use case that segments notifications based on a post's team name:

```php
add_filter('onesignal_send_notification_included_segments', 'mytheme_included_segments', 10, 4);
function mytheme_included_segments($included_segments, $new_status, $old_status, $post) {
  $team = get_post_team_name($post->ID);
  if (isset($team)) {
    $included_segments = array($team);
  }
  return $included_segments;  
}
```

I'm also seeing some potential problems with the new post selection logic in v1.8.2.  Some folks with large or complicated sites may have problems with this.  Especially if they have custom post types defined they don't want notified on.

I've made an easy fix for this by creating a filter that applies before sending the notification.  If the filter returns false, the notification won't be sent.  This way, we can pass complete control if a notification gets sent or not per post down to the user, if they choose to implement a filter for it.

If the filter is not defined in the theme, this defaults back to the original plugin behavior.

Sample use case:
```php
add_filter('onesignal_send_notification_pre_send_check', 'mytheme_send_notification_pre_send_check', 10, 4);
function mytheme_send_notification_pre_send_check($send_notification, $new_status, $old_status, $post) {
  $post_types = array('post', 'custom_post_type');
  if (! in_array( get_post_type( $post ), $post_types ) || $new_status !== "publish") {
    return false;
  }
  return $send_notifcation;
}
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/one-signal/onesignal-wordpress-plugin/12)
<!-- Reviewable:end -->
