### PR TITLE
Add option to set custom user tags

### DIFF
--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -122,6 +122,7 @@ class OneSignal_Admin {
       'welcome_notification_title',
       'welcome_notification_message',
       'welcome_notification_url',
+      'subscriberTags',
       'notifyButton_size',
       'notifyButton_theme',
       'notifyButton_position',

--- a/onesignal-public.php
+++ b/onesignal-public.php
@@ -329,7 +329,7 @@ class OneSignal_Public {
           }
         }
         if (has_filter('onesignal_subscriber_tags')) {
-          $subscriber_tags = apply_filters('onesignal_subscriber_tags');
+          $subscriber_tags = apply_filters('onesignal_subscriber_tags', $subscriber_tags);
         }
 
         if (!empty($subscriber_tags)) {

--- a/onesignal-public.php
+++ b/onesignal-public.php
@@ -314,10 +314,34 @@ class OneSignal_Public {
           }
 
         }
+
+        $subscriber_tags = null;
+        $subscriber_tags_json = null;
+        if (array_key_exists('subscriberTags', $onesignal_wp_settings) && $onesignal_wp_settings['subscriberTags'] != "") {
+          $subscriber_tag_string = $onesignal_wp_settings['subscriberTags'];
+          $tagValuePairArray = array_filter(explode(',', $subscriber_tag_string));
+
+          foreach ($tagValuePairArray as $tvp) {
+            $tag_value = explode(':', $tvp);
+            if (count($tag_value) == 2) {
+                $subscriber_tags[$tag_value[0]] = $tag_value[1];
+            }
+          }
+        }
+        if (has_filter('onesignal_subscriber_tags')) {
+          $subscriber_tags = apply_filters('onesignal_subscriber_tags');
+        }
+
+        if (!empty($subscriber_tags)) {
+          $subscriber_tags_json = json_encode($subscriber_tags);
+        }
         ?>
 
         OneSignal.init(oneSignal_options);
       });
+      <?php if(!empty($subscriber_tags_json)) { ?>
+      OneSignal.push(["sendTags", <?php echo $subscriber_tags_json ?>, function(tagsSent) {}]);
+      <?php } ?>
 
       function documentInitOneSignal() {
         var oneSignal_elements = document.getElementsByClassName("OneSignal-prompt");

--- a/onesignal-settings.php
+++ b/onesignal-settings.php
@@ -22,6 +22,7 @@ class OneSignal {
                   'default_url' => "",
                   'app_rest_api_key' => "",
                   'safari_web_id' => "",
+                  'subscriberTags' => "",
                   'prompt_customize_enable' => 'CALCULATE_SPECIAL_VALUE',
                   'prompt_action_message' => "",
                   'prompt_example_notification_title_desktop' => "",

--- a/views/config.php
+++ b/views/config.php
@@ -888,6 +888,18 @@ if (array_key_exists('app_id', $_POST)) {
             </div>
           </div>
         </div>
+        <div class="ui dividing header">
+          <i class="desktop icon"></i>
+          <div class="content">
+            Other Notification Settings
+          </div>
+        </div>
+        <div class="ui borderless shadowless segment">
+          <div class="field">
+            <label>Subscriber tags to set<i class="tiny circular help icon link" role="popup" data-title="Subscriber Tags" data-content="Sets the tags for each subscriber to the key:value pairs entered below (comma delimited). This can also be dynamically set by your theme by returning your custom tags as an associative array from the 'onesignal_subscriber_tags' filter hook." data-variation="wide"></i></label>
+            <input type="text" placeholder="<tag>:<value> pairs (comma separated).  Example - myTagName1:myTagValue1,myTagName2:myTagValue2" name="subscriberTags" value="<?php echo @$onesignal_wp_settings['subscriberTags']; ?>">
+          </div>
+        </div>
         <button class="ui large teal button" type="submit">Save</button>
         <div class="ui error message">
         </div>


### PR DESCRIPTION
References issue #13 

Can now add custom tags to users through the admin plugin panel.

Format:
tagName1:tagValue1,tagName2:tagValue2,...

We now also have a custom filter hook called 'onesignal_subscriber_tags' that allows these to be dynamically set by the theme per-user.  This filter hook expects that the tag/value pairs be returned as a standard php associative array.

Example use case:
```php
add_filter('onesignal_subscriber_tags', 'mytheme_onesignal_subscriber_tags');
function mytheme_onesignal_subscriber_tags($subscriber_tags) {
  if(is_user_logged_in()) {
    $user = wp_get_current_user();

    if ($user && $user->exists() && isPaidUser($user)) {
      return array('subscriberLevel' => 'paid');
    }
  }
  return $subscriber_tags;
}
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/one-signal/onesignal-wordpress-plugin/14)
<!-- Reviewable:end -->
