### PR TITLE
Php 5.2 compatibility

### DIFF
--- a/onesignal-public.php
+++ b/onesignal-public.php
@@ -1,7 +1,7 @@
 <?php
 
 function onesignal_debug() {
-  if (WP_DEBUG) {
+  if (defined('ONESIGNAL_DEBUG')) {
     $numargs = func_num_args();
     $arg_list = func_get_args();
     $output = '';
@@ -32,7 +32,7 @@ class OneSignal_Public {
       if (strpos(ONESIGNAL_PLUGIN_URL, "http://localhost") === false && strpos(ONESIGNAL_PLUGIN_URL, "http://127.0.0.1") === false) {
         $current_plugin_url = preg_replace("/(http:\/\/)/i", "https://", ONESIGNAL_PLUGIN_URL);
       }
-      else {
+    else {
         $current_plugin_url = ONESIGNAL_PLUGIN_URL;
       }
 ?>
@@ -47,9 +47,13 @@ class OneSignal_Public {
       ?>
     <link rel="manifest" href="<?php echo( $current_plugin_url . 'sdk_files/manifest.json.php?gcm_sender_id=' . $gcm_sender_id ) ?>" />
 <?php } ?>
-    <?php /* <script src="https://cdn.onesignal.com/sdks/OneSignalSDK.js" async></script> */ ?>
-    <?php /* <script src="https://192.168.1.206:3000/dev_sdks/OneSignalSDK.js" async></script> */ ?>
-    <script src="https://cdn.onesignal.com/sdks/OneSignalSDK.js" async></script>
+    <?php
+    if (defined('ONESIGNAL_DEBUG')) {
+        echo '<script src="https://localhost:3001/dev_sdks/OneSignalSDK.js" async></script>';
+      } else {
+        echo '<script src="https://cdn.onesignal.com/sdks/OneSignalSDK.js" async></script>';
+      }
+    ?>
     <script>
 
       var OneSignal = OneSignal || [];
@@ -62,14 +66,14 @@ class OneSignal_Public {
         <?php
 
         if ($onesignal_wp_settings['default_icon'] != "") {
-          echo "OneSignal.setDefaultIcon(\"" . html_entity_decode($onesignal_wp_settings['default_icon'], ENT_HTML401 | ENT_QUOTES, 'UTF-8') . "\");\n";
+          echo "OneSignal.setDefaultIcon(\"" . OneSignalUtils::decode_entities($onesignal_wp_settings['default_icon']) . "\");\n";
         }
 
         if ($onesignal_wp_settings['default_url'] != "") {
-          echo "OneSignal.setDefaultNotificationUrl(\"" . html_entity_decode($onesignal_wp_settings['default_url'], ENT_HTML401 | ENT_QUOTES, 'UTF-8') . "\");";
+          echo "OneSignal.setDefaultNotificationUrl(\"" . OneSignalUtils::decode_entities($onesignal_wp_settings['default_url']) . "\");";
         }
         else {
-           echo "OneSignal.setDefaultNotificationUrl(\"" . html_entity_decode(get_site_url(), ENT_HTML401 | ENT_QUOTES, 'UTF-8') . "\");\n";
+           echo "OneSignal.setDefaultNotificationUrl(\"" . OneSignalUtils::decode_entities(get_site_url()) . "\");\n";
         }
         ?>
         var oneSignal_options = {};

--- a/onesignal-utils.php
+++ b/onesignal-utils.php
@@ -1,0 +1,16 @@
+<?php
+
+
+class OneSignalUtils {
+
+	/* If >= PHP 5.4, ENT_HTML401 | ENT_QUOTES will correctly decode most entities including both double and single quotes.
+   In PHP 5.3, ENT_HTML401 does not exist, so we have to use `str_replace("&apos;","'", $value)` before feeding it to html_entity_decode(). */
+	public static function decode_entities($string) {
+		$HTML_ENTITY_DECODE_FLAGS = ENT_QUOTES;
+		if (defined('ENT_HTML401')) {
+			$HTML_ENTITY_DECODE_FLAGS = ENT_HTML401 | $HTML_ENTITY_DECODE_FLAGS;
+		}
+		return html_entity_decode(str_replace("&apos;", "'", $string), $HTML_ENTITY_DECODE_FLAGS, 'UTF-8');
+	}
+}
+?>

--- a/onesignal.php
+++ b/onesignal.php
@@ -11,6 +11,7 @@
 
 define( 'ONESIGNAL_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
+require_once( plugin_dir_path( __FILE__ ) . 'onesignal-utils.php' );
 require_once( plugin_dir_path( __FILE__ ) . 'onesignal-admin.php' );
 require_once( plugin_dir_path( __FILE__ ) . 'onesignal-public.php' );
 require_once( plugin_dir_path( __FILE__ ) . 'onesignal-settings.php' );

--- a/onesignal.php
+++ b/onesignal.php
@@ -3,7 +3,7 @@
   * Plugin Name: OneSignal Push Notifications
  * Plugin URI: https://onesignal.com/
  * Description:
- * Version: 1.9.1
+ * Version: 1.9.2
  * Author: OneSignal
  * Author URI: https://onesignal.com
  * License: MIT

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://onesignal.com
 Tags: chrome, firefox, safari, push, push notifications, push notification, chrome push, safari push, firefox push, notification, notifications, web push, notify, mavericks, android, android push, android notifications, android notification, mobile notification, mobile notifications, mobile, desktop notification, roost, goroost, desktop notifications, gcm, push messages, onesignal
 Requires at least: 3.8
 Tested up to: 4.4.2
-Stable tag: 1.9.1
+Stable tag: 1.9.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -12,7 +12,7 @@ Increase engagement and drive more repeat traffic to your WordPress site with de
 
 == Description ==
 
-[OneSignal](https://onesignal.com) is a complete push notification solution for WordPress blogs and websites, trusted by over 17,500 developers and marketers including some of the largest brands and websites in the world.
+[OneSignal](https://onesignal.com) is a complete push notification solution for WordPress blogs and websites, trusted by over 19,000 developers and marketers including some of the largest brands and websites in the world.
 
 After setup, your visitors can opt-in to receive desktop push notifications when you publish a new post, and visitors receive these notifications even after they’ve left your website.
 
@@ -50,6 +50,10 @@ Features:
 4. Our configuration settings allowing you to customize the way users are prompted to subscribe and the notifications they receive.
 
 == Changelog ==
+= 1.9.2 =
+- Make WordPress plugin compatible with PHP v5.2.4
+    - Using workaround for constant ENT_HTML401 not defined in < PHP 5.4 used in decode_html_entity
+
 = 1.9.1 =
 - Relax subdomain validation now that the web SDK auto-corrects almost-valid values
 

--- a/sdk_files/OneSignalSDKUpdaterWorker.js.php
+++ b/sdk_files/OneSignalSDKUpdaterWorker.js.php
@@ -1,5 +1,9 @@
 <?php
 	header("Service-Worker-Allowed: /");
 	header("Content-Type: application/javascript");
+	if (defined('ONESIGNAL_DEBUG')) {
+		echo "importScripts('https://localhost:3001/dev_sdks/OneSignalSDK.js');";
+	} else {
+		echo "importScripts('https://cdn.onesignal.com/sdks/OneSignalSDK.js');";
+	}
 ?>
-importScripts('https://cdn.onesignal.com/sdks/OneSignalSDK.js');

--- a/sdk_files/OneSignalSDKWorker.js.php
+++ b/sdk_files/OneSignalSDKWorker.js.php
@@ -1,5 +1,9 @@
 <?php
 	header("Service-Worker-Allowed: /");
 	header("Content-Type: application/javascript");
+	if (defined('ONESIGNAL_DEBUG')) {
+		echo "importScripts('https://localhost:3001/dev_sdks/OneSignalSDK.js');";
+	} else {
+		echo "importScripts('https://cdn.onesignal.com/sdks/OneSignalSDK.js');";
+	}
 ?>
-importScripts('https://cdn.onesignal.com/sdks/OneSignalSDK.js');


### PR DESCRIPTION
Plugin now compatible with PHP v5.2; fixing ENT_HTML401 constant not defined in PHP v5.2.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/one-signal/onesignal-wordpress-plugin/15)
<!-- Reviewable:end -->
