### PR TITLE
Logging

### DIFF
--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -20,7 +20,7 @@ class OneSignal_Admin {
 			  try {
 				  switch ($errno) {
 					  case E_USER_ERROR:
-						  onesignal_debug('[FATAL ERROR]', $errstr . ' @ ' . $errfile . ':' . $errline);
+						  onesignal_debug('[ERROR]', $errstr . ' @ ' . $errfile . ':' . $errline);
 						  exit(1);
 						  break;
 
@@ -37,7 +37,7 @@ class OneSignal_Admin {
 						  break;
 
 					  default:
-						  onesignal_debug('[UNKNOWN EXCEPTION]', '(' . $errno . '): ' . $errstr . ' @ ' . $errfile . ':' . $errline);
+						  onesignal_debug('[UNKNOWN ERROR]', '(' . $errno . '): ' . $errstr . ' @ ' . $errfile . ':' . $errline);
 						  break;
 				  }
 
@@ -48,6 +48,28 @@ class OneSignal_Admin {
 		  }
 
 		  set_error_handler("exception_error_handler");
+
+		  function fatal_exception_error_handler() {
+			  $error = error_get_last();
+			  try {
+				  switch ($error['type']) {
+					  case E_ERROR:
+					  case E_CORE_ERROR:
+					  case E_COMPILE_ERROR:
+					  case E_USER_ERROR:
+					  case E_RECOVERABLE_ERROR:
+					  case E_CORE_WARNING:
+					  case E_COMPILE_WARNING:
+					  case E_PARSE:
+						  onesignal_debug('[CRITICAL ERROR]', '(' . $error['type'] . ') ' . $error['message'] . ' @ ' . $error['file'] . ':' . $error['line']);
+				  }
+			  } catch (Exception $ex) {
+				  return true;
+			  }
+		  }
+
+		  register_shutdown_function('fatal_exception_error_handler');
+		  //spl_autoload_register('foo');
 	  }
 
     if (current_user_can('update_plugins')) {
@@ -443,6 +465,11 @@ class OneSignal_Admin {
           ob_start();
           $out = fopen('php://output', 'w');
         }
+
+	      if (!function_exists('curl_init')) {
+		      onesignal_debug('curl_init() is not a defined function. cURL needs to be installed on this server!');
+		      return;
+	      }
 
         $ch = curl_init();
 

--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -114,10 +114,6 @@ class OneSignal_Admin {
       }
     }
 
-    /*
-     * Never add onesignal_debug() statements above this line or they will recursively output.
-     */
-
     /* OK, it's safe for us to save the data now. */
 
     // Sanitize the user input.
@@ -442,7 +438,7 @@ class OneSignal_Admin {
 		      onesignal_debug('onesignal_send_notification filter $fields result:', $fields);
 	      }
 
-        if (defined('ONESIGNAL_DEBUG')) {
+	      if (class_exists('WDS_Log_Post')) {
           // http://blog.kettle.io/debugging-curl-requests-in-php/
           ob_start();
           $out = fopen('php://output', 'w');
@@ -472,7 +468,7 @@ class OneSignal_Admin {
         curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($fields));
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
 
-        if (defined('ONESIGNAL_DEBUG')) {
+	      if (class_exists('WDS_Log_Post')) {
           curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
           curl_setopt($ch, CURLOPT_FAILONERROR, false);
           curl_setopt($ch, CURLOPT_HTTP200ALIASES, array(400));
@@ -482,7 +478,7 @@ class OneSignal_Admin {
 
         $response = curl_exec($ch);
 
-        if (defined('ONESIGNAL_DEBUG')) {
+	      if (class_exists('WDS_Log_Post')) {
           fclose($out);
           $debug_output = ob_get_clean();
 

--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -397,6 +397,10 @@ class OneSignal_Admin {
   
   public static function send_notification_on_wp_post($new_status, $old_status, $post) {
     try {
+	    if (!function_exists('curl_init')) {
+		    return;
+	    }
+
       $onesignal_wp_settings = OneSignal::get_onesignal_settings();
 
 	    /* Looks like on_save_post is called after transition_post_status so we'll have to check POST data in addition to post meta data */

--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -72,19 +72,6 @@ class OneSignal_Admin {
 		  //spl_autoload_register('foo');
 	  }
 
-	  if (!function_exists('curl_init')) {
-		  add_action( 'admin_notices', 'admin_notice_curl_not_installed');
-
-		  function admin_notice_curl_not_installed() {
-			  ?>
-			  <div class="error notice">
-				  <p><?php echo '<strong>OneSignal Push:</strong> <em>cURL is not installed on this server. cURL is required to send notifications. Please make sure cURL is installed on your server before continuing.</em>'; ?></p>
-			  </div>
-			  <?php
-		  }
-		  return;
-	  }
-
     if (current_user_can('update_plugins')) {
       add_action( 'admin_menu', array(__CLASS__, 'add_admin_page') );
     }
@@ -363,7 +350,34 @@ class OneSignal_Admin {
   }
 
   public static function admin_custom_load() {
-    add_action( 'admin_enqueue_scripts', array(__CLASS__, 'admin_custom_scripts') );
+	  add_action('admin_enqueue_scripts', array(__CLASS__, 'admin_custom_scripts'));
+
+	  $onesignal_wp_settings = OneSignal::get_onesignal_settings();
+	  if (
+		  $onesignal_wp_settings['app_id'] == '' ||
+		  $onesignal_wp_settings['app_rest_api_key'] == ''
+	  ) {
+		  function admin_notice_setup_not_complete() {
+			  ?>
+			  <div class="error notice onesignal-error-notice">
+				  <p><?php echo '<strong>OneSignal Push:</strong> <em>Your setup is not complete. Please follow the Setup guide to set up web push notifications.</em>'; ?></p>
+			  </div>
+			  <?php
+		  }
+
+		  add_action('admin_notices', 'admin_notice_setup_not_complete');
+	  }
+
+	  if (!function_exists('curl_init')) {
+		  function admin_notice_curl_not_installed() {
+			  ?>
+			  <div class="error notice onesignal-error-notice">
+				  <p><?php echo '<strong>OneSignal Push:</strong> <em>cURL is not installed on this server. cURL is required to send notifications. Please make sure cURL is installed on your server before continuing.</em>'; ?></p>
+			  </div>
+			  <?php
+		  }
+		  add_action( 'admin_notices', 'admin_notice_curl_not_installed');
+	  }
   }
   
   public static function admin_custom_scripts() {

--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -72,6 +72,19 @@ class OneSignal_Admin {
 		  //spl_autoload_register('foo');
 	  }
 
+	  if (!function_exists('curl_init')) {
+		  add_action( 'admin_notices', 'admin_notice_curl_not_installed');
+
+		  function admin_notice_curl_not_installed() {
+			  ?>
+			  <div class="error notice">
+				  <p><?php echo '<strong>OneSignal Push:</strong> <em>cURL is not installed on this server. cURL is required to send notifications. Please make sure cURL is installed on your server before continuing.</em>'; ?></p>
+			  </div>
+			  <?php
+		  }
+		  return;
+	  }
+
     if (current_user_can('update_plugins')) {
       add_action( 'admin_menu', array(__CLASS__, 'add_admin_page') );
     }
@@ -465,11 +478,6 @@ class OneSignal_Admin {
           ob_start();
           $out = fopen('php://output', 'w');
         }
-
-	      if (!function_exists('curl_init')) {
-		      onesignal_debug('curl_init() is not a defined function. cURL needs to be installed on this server!');
-		      return;
-	      }
 
         $ch = curl_init();
 

--- a/onesignal-public.php
+++ b/onesignal-public.php
@@ -1,15 +1,22 @@
 <?php
 
 function onesignal_debug() {
+  $numargs = func_num_args();
+  $arg_list = func_get_args();
+  $output = '';
+  for ($i = 0; $i < $numargs; $i++) {
+    $output = $output . var_export($arg_list[$i], true) . ', ';
+  }
+  $output = substr($output, 0, 1024);
+
   if (defined('ONESIGNAL_DEBUG')) {
-    $numargs = func_num_args();
-    $arg_list = func_get_args();
-    $output = '';
-    for ($i = 0; $i < $numargs; $i++) {
-      $output = $output . var_export($arg_list[$i], true) . ', ';
-    }
-    $output = substr($output, 0, -2);
     error_log('OneSignal: ' . $output);
+  }
+  if (class_exists('WDS_Log_Post')) {
+    $num_log_posts = wp_count_posts('wdslp-wds-log', 'readable');
+    if ($num_log_posts->publish < 500) {
+      WDS_Log_Post::log_message($output, '', 'general');
+    }
   }
 }
 
@@ -22,7 +29,7 @@ class OneSignal_Public {
   public function __construct() {}
 
   public static function init() {
-    add_action( 'wp_head', array( __CLASS__, 'onesignal_header' ), 1 );
+    add_action('wp_head', array(__CLASS__, 'onesignal_header'), 1);
   }
 
   public static function onesignal_header() {

--- a/onesignal-public.php
+++ b/onesignal-public.php
@@ -5,9 +5,25 @@ function onesignal_debug() {
   $arg_list = func_get_args();
   $output = '';
   for ($i = 0; $i < $numargs; $i++) {
-    $output = $output . var_export($arg_list[$i], true) . ', ';
+    $arg = $arg_list[$i];
+
+    if (is_string($arg)) {
+      $arg_output = $arg;
+    } else {
+      $arg_output = var_export($arg, true);
+    }
+
+    if ($arg === "") {
+      $arg_output = "\"\"";
+    }
+    else if ($arg === null) {
+      $arg_output = "null";
+    }
+
+    $output = $output . $arg_output . ' ';
   }
-  $output = substr($output, 0, 1024);
+  $output = substr($output, 0, -1);
+  //$output = substr($output, 0, 1024);
 
   if (defined('ONESIGNAL_DEBUG')) {
     error_log('OneSignal: ' . $output);

--- a/onesignal-public.php
+++ b/onesignal-public.php
@@ -1,12 +1,15 @@
 <?php
 
 function onesignal_debug() {
-  $numargs = func_num_args();
+  if (!defined('ONESIGNAL_DEBUG') && !class_exists('WDS_Log_Post')) {
+    return;
+  }
+  $numargs  = func_num_args();
   $arg_list = func_get_args();
-  $bt = debug_backtrace();
-  $output = '[' . $bt[1]['function'] . '] ';
-  for ($i = 0; $i < $numargs; $i++) {
-    $arg = $arg_list[$i];
+  $bt       = debug_backtrace();
+  $output   = '[' . $bt[1]['function'] . '] ';
+  for ($i = 0; $i < $numargs; $i ++) {
+    $arg = $arg_list[ $i ];
 
     if (is_string($arg)) {
       $arg_output = $arg;
@@ -16,25 +19,36 @@ function onesignal_debug() {
 
     if ($arg === "") {
       $arg_output = "\"\"";
-    }
-    else if ($arg === null) {
+    } else if ($arg === null) {
       $arg_output = "null";
     }
 
     $output = $output . $arg_output . ' ';
   }
-  $output = substr($output, 0, -1);
-  //$output = substr($output, 0, 1024);
-
+  $output = substr($output, 0, - 1);
+  $output = substr($output, 0, 1024); // Restrict messages to 1024 characters in length
   if (defined('ONESIGNAL_DEBUG')) {
     error_log('OneSignal: ' . $output);
   }
   if (class_exists('WDS_Log_Post')) {
     $num_log_posts = wp_count_posts('wdslp-wds-log', 'readable');
+    // Limit the total number of log entries to 500
     if ($num_log_posts->publish < 500) {
       WDS_Log_Post::log_message($output, '', 'general');
     }
   }
+}
+
+function onesignal_debug_post($post) {
+  if (!$post) {
+    return;
+  }
+  return onesignal_debug('Post:', array('ID' => $post->ID,
+                        'Post Date' => $post->post_date,
+                        'Modified Date' => $post->post_modified,
+                        'Title' => $post->post_title,
+                        'Status:' => $post->post_status,
+                        'Type:' => $post->post_type));
 }
 
 function print_settings() {

--- a/onesignal-public.php
+++ b/onesignal-public.php
@@ -3,7 +3,8 @@
 function onesignal_debug() {
   $numargs = func_num_args();
   $arg_list = func_get_args();
-  $output = '';
+  $bt = debug_backtrace();
+  $output = '[' . $bt[1]['function'] . '] ';
   for ($i = 0; $i < $numargs; $i++) {
     $arg = $arg_list[$i];
 

--- a/onesignal.php
+++ b/onesignal.php
@@ -3,7 +3,7 @@
   * Plugin Name: OneSignal Push Notifications
  * Plugin URI: https://onesignal.com/
  * Description: Free web push notifications.
- * Version: 1.10.0
+ * Version: 1.10.1
  * Author: OneSignal
  * Author URI: https://onesignal.com
  * License: MIT

--- a/onesignal.php
+++ b/onesignal.php
@@ -3,7 +3,7 @@
   * Plugin Name: OneSignal Push Notifications
  * Plugin URI: https://onesignal.com/
  * Description: Free web push notifications.
- * Version: 2.0.0
+ * Version: 1.10.0
  * Author: OneSignal
  * Author URI: https://onesignal.com
  * License: MIT

--- a/onesignal.php
+++ b/onesignal.php
@@ -2,8 +2,8 @@
 /**
   * Plugin Name: OneSignal Push Notifications
  * Plugin URI: https://onesignal.com/
- * Description:
- * Version: 1.9.2
+ * Description: Free web push notifications.
+ * Version: 2.0.0
  * Author: OneSignal
  * Author URI: https://onesignal.com
  * License: MIT

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://onesignal.com
 Tags: chrome, firefox, safari, push, push notifications, push notification, chrome push, safari push, firefox push, notification, notifications, web push, notify, mavericks, android, android push, android notifications, android notification, mobile notification, mobile notifications, mobile, desktop notification, roost, goroost, desktop notifications, gcm, push messages, onesignal
 Requires at least: 3.8
 Tested up to: 4.4.2
-Stable tag: 1.9.2
+Stable tag: 2.0.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -12,7 +12,7 @@ Increase engagement and drive more repeat traffic to your WordPress site with de
 
 == Description ==
 
-[OneSignal](https://onesignal.com) is a complete push notification solution for WordPress blogs and websites, trusted by over 19,000 developers and marketers including some of the largest brands and websites in the world.
+[OneSignal](https://onesignal.com) is a complete push notification solution for WordPress blogs and websites, trusted by over 20,500 developers and marketers including some of the largest brands and websites in the world.
 
 After setup, your visitors can opt-in to receive desktop push notifications when you publish a new post, and visitors receive these notifications even after they’ve left your website.
 
@@ -50,6 +50,12 @@ Features:
 4. Our configuration settings allowing you to customize the way users are prompted to subscribe and the notifications they receive.
 
 == Changelog ==
+= 2.0.0 =
+- Fix scheduled notifications to be more reliable by associating data with the post's metadata and rewriting the send notification logic
+- Modified the WDS Log plugin to log OneSignal-related things; WDS Log plugin must be installed to view
+- Add a filter hook for to modify the data we post to create notifications API to allow customizing of notifications
+- Fixed Configuration page saving so that a user can choose to only use the Safari platform and skip the Chrome subdomain
+
 = 1.9.2 =
 - Make WordPress plugin compatible with PHP v5.2.4
     - Using workaround for constant ENT_HTML401 not defined in < PHP 5.4 used in decode_html_entity

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://onesignal.com
 Tags: chrome, firefox, safari, push, push notifications, push notification, chrome push, safari push, firefox push, notification, notifications, web push, notify, mavericks, android, android push, android notifications, android notification, mobile notification, mobile notifications, mobile, desktop notification, roost, goroost, desktop notifications, gcm, push messages, onesignal
 Requires at least: 3.8
 Tested up to: 4.4.2
-Stable tag: 2.0.0
+Stable tag: 1.10.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -50,7 +50,7 @@ Features:
 4. Our configuration settings allowing you to customize the way users are prompted to subscribe and the notifications they receive.
 
 == Changelog ==
-= 2.0.0 =
+= 1.10.0 =
 - Fix scheduled notifications to be more reliable by associating data with the post's metadata and rewriting the send notification logic
 - Modified the WDS Log plugin to log OneSignal-related things; WDS Log plugin must be installed to view
 - Add a filter hook for to modify the data we post to create notifications API to allow customizing of notifications

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://onesignal.com
 Tags: chrome, firefox, safari, push, push notifications, push notification, chrome push, safari push, firefox push, notification, notifications, web push, notify, mavericks, android, android push, android notifications, android notification, mobile notification, mobile notifications, mobile, desktop notification, roost, goroost, desktop notifications, gcm, push messages, onesignal
 Requires at least: 3.8
 Tested up to: 4.4.2
-Stable tag: 1.10.0
+Stable tag: 1.10.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -50,6 +50,9 @@ Features:
 4. Our configuration settings allowing you to customize the way users are prompted to subscribe and the notifications they receive.
 
 == Changelog ==
+= 1.10.1 =
+- Automatic sending functionality has been rewritten
+
 = 1.10.0 =
 - Fix scheduled notifications to be more reliable by associating data with the post's metadata and rewriting the send notification logic
 - Modified the WDS Log plugin to log OneSignal-related things; WDS Log plugin must be installed to view

--- a/views/config.php
+++ b/views/config.php
@@ -1,5 +1,9 @@
 <?php
 $onesignal_wp_settings = OneSignal::get_onesignal_settings();
+
+if (array_key_exists('app_id', $_POST)) {
+  $onesignal_wp_settings = OneSignal_Admin::save_config_page($_POST);
+}
 ?>
 
 <header class="onesignal">
@@ -556,11 +560,11 @@ $onesignal_wp_settings = OneSignal::get_onesignal_settings();
             <input type="text" name="app_rest_api_key" placeholder="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" value="<?php echo $onesignal_wp_settings['app_rest_api_key'] ?>">
           </div>
           <div class="field subdomain-feature">
-            <label>Subdomain<i class="tiny circular help icon link" role="popup" data-title="Subdomain" data-content="Your chosen subdomain. You can find this on Setup > Chrome & Firefox Push > Step 9." data-variation="wide"></i></label>
+            <label>OneSignal Subdomain<i class="tiny circular help icon link" role="popup" data-title="Subdomain" data-content="Your chosen OneSignal subdomain, not your site subdomain. You can find this on Setup > Chrome & Firefox Push > Step 9." data-variation="wide"></i></label>
             <input type="text" name="subdomain" placeholder="example" value="<?php echo $onesignal_wp_settings['subdomain'] ?>">
           </div>
           <div class="field">
-            <label>Safari Web ID<i class="tiny circular help icon link" role="popup" data-title="Safari Web ID" data-content="Your chosen subdomain. You can find this on Setup > Safari Push > Step 5." data-variation="wide"></i></label>
+            <label>Safari Web ID<i class="tiny circular help icon link" role="popup" data-title="Safari Web ID" data-content="Your Safari Web ID. You can find this on Setup > Safari Push > Step 5." data-variation="wide"></i></label>
             <input type="text" name="safari_web_id" placeholder="web.com.example" value="<?php echo @$onesignal_wp_settings['safari_web_id']; ?>">
           </div>
         </div>
@@ -905,7 +909,11 @@ $onesignal_wp_settings = OneSignal::get_onesignal_settings();
           </div>
         </div>
         <button class="ui large teal button" type="submit">Save</button>
-        <div class="ui error message">
+        <div class="ui inline validation nag">
+            <span class="title">
+              Your OneSignal subdomain cannot be empty or less than 4 characters. Use the same one you entered on the platform settings at onesignal.com.
+            </span>
+          <i class="close icon"></i>
         </div>
       </form>
     </div>

--- a/views/config.php
+++ b/views/config.php
@@ -878,13 +878,13 @@ if (array_key_exists('app_id', $_POST)) {
           <div class="field">
             <div class="ui toggle checkbox">
               <input type="checkbox" name="notification_on_post" value="true" <?php if ($onesignal_wp_settings['notification_on_post']) { echo "checked"; } ?>>
-              <label>Suggest to send a push notification when creating any kind of post<i class="tiny circular help icon link" role="popup" data-title="Automatic Push from WordPress Editor" data-content="If checked, when you create a new post, the checkbox 'Send notification on post publish/update' will be automatically checked." data-variation="wide"></i></label>
+              <label>Automatically send a push notification when I create a post from the WordPress editor<i class="tiny circular help icon link" role="popup" data-title="Automatic Push from WordPress Editor" data-content="If checked, when you create a new post from WordPress's editor, the checkbox 'Send notification on post publish/update' will be automatically checked. The checkbox can be unchecked to prevent sending a notification." data-variation="wide"></i></label>
             </div>
           </div>
           <div class="field">
             <div class="ui toggle checkbox">
               <input type="checkbox" name="notification_on_post_from_plugin" value="true" <?php if (@$onesignal_wp_settings['notification_on_post_from_plugin']) { echo "checked"; } ?>>
-              <label>Automatically send a push notification when I publish a post<i class="tiny circular help icon link" role="popup" data-title="Automatic Push" data-content="If checked, when you publish a post, a push notification will always be sent. Post type must be exactly 'post' and post status must be 'publish'." data-variation="wide"></i></label>
+              <label>Automatically send a push notification when I publish a post from 3<sup>rd</sup> party plugins<i class="tiny circular help icon link" role="popup" data-title="Automatic Push outside WordPress Editor" data-content="If checked, when a post is created outside of WordPress's editor, a push notification will automatically be sent. Must be the built-in WordPress post type 'post' and the post must be published." data-variation="wide"></i></label>
             </div>
           </div>
         </div>

--- a/views/config.php
+++ b/views/config.php
@@ -1,9 +1,5 @@
 <?php
 $onesignal_wp_settings = OneSignal::get_onesignal_settings();
-
-if (array_key_exists('app_id', $_POST)) {
-  $onesignal_wp_settings = OneSignal_Admin::save_config_page($_POST);
-}
 ?>
 
 <header class="onesignal">

--- a/views/config.php
+++ b/views/config.php
@@ -874,13 +874,13 @@ $onesignal_wp_settings = OneSignal::get_onesignal_settings();
           <div class="field">
             <div class="ui toggle checkbox">
               <input type="checkbox" name="notification_on_post" value="true" <?php if ($onesignal_wp_settings['notification_on_post']) { echo "checked"; } ?>>
-              <label>Automatically send a push notification when I create a post from the default WordPress editor<i class="tiny circular help icon link" role="popup" data-title="Automatic Push from WordPress Editor" data-content="If checked, when you create a new post, the checkbox 'Send notification on publish' will be automatically checked." data-variation="wide"></i></label>
+              <label>Suggest to send a push notification when creating any kind of post<i class="tiny circular help icon link" role="popup" data-title="Automatic Push from WordPress Editor" data-content="If checked, when you create a new post, the checkbox 'Send notification on post publish/update' will be automatically checked." data-variation="wide"></i></label>
             </div>
           </div>
           <div class="field">
             <div class="ui toggle checkbox">
               <input type="checkbox" name="notification_on_post_from_plugin" value="true" <?php if (@$onesignal_wp_settings['notification_on_post_from_plugin']) { echo "checked"; } ?>>
-              <label>Automatically send a push notification when I create a post from 3<sup>rd</sup> party plugins<i class="tiny circular help icon link" role="popup" data-title="Automatic Push from 3rd Party Editors" data-content="If checked, when you create a new post from most 3rd party plugins, the checkbox 'Send notification on publish' will be automatically checked." data-variation="wide"></i></label>
+              <label>Automatically send a push notification when I publish a post<i class="tiny circular help icon link" role="popup" data-title="Automatic Push" data-content="If checked, when you publish a post, a push notification will always be sent. Post type must be exactly 'post' and post status must be 'publish'." data-variation="wide"></i></label>
             </div>
           </div>
         </div>

--- a/views/css/site.css
+++ b/views/css/site.css
@@ -669,6 +669,9 @@ header[class=onesignal] {
   color: white; }
   .ui.site.onesignal.container .ui.inline.nag.subdomain-http {
     background: purple; }
+  .ui.site.onesignal.container .ui.inline.nag.validation {
+    margin-top: 1em;
+    background: red; }
   .ui.site.onesignal.container .ui.inline.nag.save-settings {
     background: green; }
 

--- a/views/css/site.css
+++ b/views/css/site.css
@@ -446,6 +446,13 @@ input::selection {
 /*******************************
         Global Overrides
 *******************************/
+.onesignal-error-notice {
+  color: #b30024 !important;
+  background: rgba(255, 0, 51, 0.085) !important;
+  margin: 0 !important; }
+  .onesignal-error-notice + .onesignal-error-notice {
+    margin-top: 5px !important; }
+
 /*******************************
          Site Overrides
 *******************************/

--- a/views/css/site.scss
+++ b/views/css/site.scss
@@ -177,7 +177,15 @@ input::selection {
 /*******************************
         Global Overrides
 *******************************/
+.onesignal-error-notice {
+    color: darken(#ff0033, 15%) !important;
+    background: rgba(255, 0, 51, 0.085) !important;
+    margin: 0 !important;
 
+    &+.onesignal-error-notice {
+        margin-top: 5px !important;
+    }
+}
 
 
 /*******************************

--- a/views/css/site.scss
+++ b/views/css/site.scss
@@ -553,6 +553,11 @@ header[class=onesignal] {
             background: purple;
         }
 
+        &.validation {
+            margin-top: 1em;
+            background: red;
+        }
+
         &.save-settings {
             background: green;
         }

--- a/views/javascript/site-admin.js
+++ b/views/javascript/site-admin.js
@@ -28,24 +28,20 @@ jQuery(function() {
 
   setupModalPopupSwitcharoo();
 
-  $('.ui.form')
-    .form({
-      fields: {
-        subdomain: {
-          identifier: 'subdomain',
-          rules: [
-            {
-              type   : 'empty',
-              prompt : 'Because your site is HTTP, you must enter a subdomain. Use the same one you entered on our OneSignal dashboard.'
-            },
-            {
-              type   : 'minLength[4]',
-              prompt : 'Your subdomain must be at least 4 characters long. Use the same one you entered on our OneSignal dashboard.'
-            }
-          ]
-        }
+  function onFormSubmit(e) {
+    var safariWebId = $('[name=safari_web_id]').val();
+    var subdomain = $('[name=subdomain]').val();
+    if (safariWebId !== '' && subdomain === '') {
+    } else {
+      if (subdomain == '' || subdomain.length < 4) {
+        e.preventDefault();
+        jQuery('.validation.nag').nag('clear');
+        jQuery('.validation.nag').nag('show');
       }
-    });
+    }
+  }
+
+  $('.ui.form').submit(onFormSubmit);
 });
 
 function httpSiteCheck() {


### PR DESCRIPTION
- Fix scheduled notifications to be more reliable by associating data with the post's metadata and rewriting the send notification logic
- Modified the [WDS Log plugin](https://github.com/one-signal/WDS-Log-Post/releases/tag/1.0) to log OneSignal-related things; WDS Log plugin must be installed to view
- Changing wording of "Automatically send post from creating from 3rd party plugins" to "Automatically send a push notification when I publish a post" (this is more accurate to what it does)
- Fix the \\\\\'s issue when saving with quotes, double quotes in text boxes in Config page
- Add a filter hook for to modify the data we post to create notifications API to allow customizing of notifications
- Fixed Configuration page saving so that a user can choose to only use the Safari platform and skip the Chrome subdomain
- Added admin banner notices (on the plugin page) if cURL is not installed or the user's setup is not complete

![image](https://cloud.githubusercontent.com/assets/1015970/13693600/6b036df4-e701-11e5-818b-f91bbe885480.png)

![image](https://cloud.githubusercontent.com/assets/1015970/13695280/d87dcb30-e711-11e5-84da-b630397dc8e7.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/one-signal/onesignal-wordpress-plugin/18)
<!-- Reviewable:end -->
