### PR TITLE
Add support for additional post statuses  

### DIFF
--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -215,7 +215,7 @@ class OneSignal_Admin {
 	  // We check the checkbox if: setting is enabled on Config page, post type is ONLY "post", and the post has not been published (new posts are status "auto-draft")
 	  $meta_box_checkbox_send_notification = $settings_send_notification_on_wp_editor_post &&  // If setting is enabled
 	                                $post->post_type == "post" &&  // Post type must be type post for checkbox to be auto-checked
-	                                $post->post_status == "auto-draft";  // Post must be newly created, not updated or already published
+	                                in_array($post->post_status, array("future", "draft", "auto-draft", "pending"));  // Post must be newly created, not updated or already published
 	  onesignal_debug('$meta_box_checkbox_send_notification:', $meta_box_checkbox_send_notification);
     onesignal_debug('    [$meta_box_checkbox_send_notification]', '$settings_send_notification_on_wp_editor_post:', $settings_send_notification_on_wp_editor_post);
     onesignal_debug('    [$meta_box_checkbox_send_notification]', '$post->post_type == "post":', $post->post_type == "post", '(' . $post->post_type . ')');

--- a/onesignal.php
+++ b/onesignal.php
@@ -3,7 +3,7 @@
   * Plugin Name: OneSignal Push Notifications
  * Plugin URI: https://onesignal.com/
  * Description: Free web push notifications.
- * Version: 1.10.5
+ * Version: 1.10.6
  * Author: OneSignal
  * Author URI: https://onesignal.com
  * License: MIT


### PR DESCRIPTION
We had an issue with scheduled posts not getting any notifications sent out. Turns out the issue was that the script only checked for status type "auto-draft". The following additional types were added:

- Draft
- Future
- Pending

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/one-signal/onesignal-wordpress-plugin/21)
<!-- Reviewable:end -->
