### PR TITLE
Updated async attribute.

### DIFF
--- a/onesignal-public.php
+++ b/onesignal-public.php
@@ -2,16 +2,6 @@
 
 defined('ABSPATH') or die('This page may not be accessed directly.');
 
-function add_async_for_script($url)
-{
-	if (strpos($url, '#asyncload') === false)
-	    return $url;
-	else if (is_admin())
-	    return str_replace('#asyncload', '', $url);
-	else
-	    return str_replace('#asyncload', '', $url)."' async='async";
-}
-
 class OneSignal_Public
 {
     public function __construct()
@@ -77,13 +67,11 @@ class OneSignal_Public
             OneSignal_Public::insert_onesignal_stamp();
         } ?>
     <?php
-    add_filter('clean_url', 'add_async_for_script', 11, 1);
-
     if (defined('ONESIGNAL_DEBUG') && defined('ONESIGNAL_LOCAL')) {
-        wp_register_script('local_sdk', 'https://localhost:3001/sdks/OneSignalSDK.js#asyncload', array(), false, true);
+	wp_register_script('local_sdk', 'https://localhost:3001/sdks/OneSignalSDK.js', array(), '1.0.0', array('strategy' => 'async'));
         wp_enqueue_script('local_sdk');
     } else {
-        wp_register_script('remote_sdk', 'https://cdn.onesignal.com/sdks/OneSignalSDK.js#asyncload', array(), false, true);
+        wp_register_script('remote_sdk', 'https://cdn.onesignal.com/sdks/OneSignalSDK.js', array(), '1.0.0', array('strategy' => 'async'));
         wp_enqueue_script('remote_sdk');
     } ?>
     <script>


### PR DESCRIPTION
Updated async attribute to correct implementation.

This change in version WordPress 6.3, to allow scripts to have async defer added when enqueueing: https://make.wordpress.org/core/2023/07/14/registering-scripts-with-async-and-defer-attributes-in-wordpress-6-3/

Original code causes issues for some folks whereby the src was added as src="https://cdn.onesignal.com/sdks/OneSignalSDK.js' async='async" causing a 404. Originally assumed to be CDn/Optimise type plugin problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-WordPress-Plugin/324)
<!-- Reviewable:end -->
