### PR TITLE
i18n: Add translation support for all user-facing strings

### DIFF
--- a/onesignal.php
+++ b/onesignal.php
@@ -10,6 +10,8 @@ defined('ABSPATH') or die('This page may not be accessed directly.');
  * Author: OneSignal
  * Author URI: https://onesignal.com
  * License: MIT
+ * Text Domain: onesignal-free-web-push-notifications
+ * Domain Path: /languages
  */
 
 // Define plugin constants
@@ -72,7 +74,7 @@ function migration_notice() {
     $screen = get_current_screen();
     if ($screen && $screen->id === 'plugins') {
         echo '<div class="notice notice-warning is-dismissible">
-                <p><strong>OneSignal Migration Needed:</strong> All OneSignal prompt configurations are moving to OneSignal.com. See the plugin page for more info.</p>
+                <p><strong>' . esc_html__( 'OneSignal Migration Needed:', 'onesignal-free-web-push-notifications' ) . '</strong> ' . esc_html__( 'All OneSignal prompt configurations are moving to OneSignal.com. See the plugin page for more info.', 'onesignal-free-web-push-notifications' ) . '</p>
               </div>';
     }
 }

--- a/v2/onesignal-admin.php
+++ b/v2/onesignal-admin.php
@@ -241,7 +241,7 @@ class OneSignal_Admin
 
         // Add our meta box for the "post" post type (default)
         add_meta_box('onesignal_notif_on_post',
-                 'OneSignal Push Notifications',
+                 __( 'OneSignal Push Notifications', 'onesignal-free-web-push-notifications' ),
                  array(__CLASS__, 'onesignal_notif_on_post_html_view'),
                  'post',
                  'side',
@@ -258,7 +258,7 @@ class OneSignal_Admin
         foreach ($post_types  as $post_type) {
             add_meta_box(
         'onesignal_notif_on_post',
-        'OneSignal Push Notifications',
+        __( 'OneSignal Push Notifications', 'onesignal-free-web-push-notifications' ),
         array(__CLASS__, 'onesignal_notif_on_post_html_view'),
         $post_type,
         'side',
@@ -317,9 +317,11 @@ class OneSignal_Admin
               } ?>></input>
 
           <?php if ($post->post_status === 'publish') {
-              echo esc_attr('Send notification on '.$post_type.' update');
+              /* translators: %s: post type (e.g. post, page) */
+              echo esc_attr( sprintf( __( 'Send notification on %s update', 'onesignal-free-web-push-notifications' ), $post_type ) );
           } else {
-              echo esc_attr('Send notification on '.$post_type.' publish');
+              /* translators: %s: post type (e.g. post, page) */
+              echo esc_attr( sprintf( __( 'Send notification on %s publish', 'onesignal-free-web-push-notifications' ), $post_type ) );
 
          } ?>
         </label>
@@ -328,21 +330,21 @@ class OneSignal_Admin
       <div id="onesignal_custom_contents_preferences">
         <input type="checkbox" id="onesignal_modify_title_and_content" value="true" name="onesignal_modify_title_and_content" <?php if ($onesignal_customize_content_checked) {
                   echo 'checked';
-              } ?>></input> Customize notification content</label>
+              } ?>></input> <?php esc_html_e( 'Customize notification content', 'onesignal-free-web-push-notifications' ); ?></label>
 
         <div id="onesignal_custom_contents" style="display:none;padding-top:10px;">
           <div>
-            <label>Notification Title<br/>
+            <label><?php esc_html_e( 'Notification Title', 'onesignal-free-web-push-notifications' ); ?><br/>
             <input type="text" size="16" style="width:220px;" name="onesignal_notification_custom_heading" value="<?php
               echo esc_attr(OneSignalUtils::decode_entities($onesignal_notification_custom_heading));
              ?>" id="onesignal_notification_custom_heading" placeholder="<?php echo esc_attr(OneSignalUtils::decode_entities($onesignal_wp_settings['notification_title'])); ?>"></input>
             </label>
           </div>
           <div style="padding-top:10px">
-            <label>Notification Text<br/>
+            <label><?php esc_html_e( 'Notification Text', 'onesignal-free-web-push-notifications' ); ?><br/>
             <input type="text" size="16" style="width:220px;" name="onesignal_notification_custom_content" value="<?php
               echo esc_attr(OneSignalUtils::decode_entities($onesignal_notification_custom_content));
-              ?>" id="onesignal_notification_custom_content" placeholder="The Post's Current Title"></input>
+              ?>" id="onesignal_notification_custom_content" placeholder="<?php echo esc_attr( __( "The Post's Current Title", 'onesignal-free-web-push-notifications' ) ); ?>"></input>
             </label>
           </div>
         </div>
@@ -382,7 +384,7 @@ class OneSignal_Admin
     {
         if (!OneSignalUtils::can_modify_plugin_settings()) {
             set_transient('onesignal_transient_error', '<div class="error notice onesignal-error-notice">
-                    <p><strong>OneSignal Push:</strong><em> Only administrators are allowed to save plugin settings.</em></p>
+                    <p><strong>' . esc_html__( 'OneSignal Push:', 'onesignal-free-web-push-notifications' ) . '</strong><em> ' . esc_html__( 'Only administrators are allowed to save plugin settings.', 'onesignal-free-web-push-notifications' ) . '</em></p>
                 </div>', 86400);
 
             return;
@@ -571,7 +573,7 @@ class OneSignal_Admin
                   });
               </script>
 			  <div class="error notice onesignal-error-notice">
-				  <p><strong>OneSignal Push:</strong> <em>Your setup is not complete. Please follow the Setup guide to set up web push notifications. Both the App ID and REST API Key fields are required.</em></p>
+				  <p><strong><?php esc_html_e( 'OneSignal Push:', 'onesignal-free-web-push-notifications' ); ?></strong> <em><?php esc_html_e( 'Your setup is not complete. Please follow the Setup guide to set up web push notifications. Both the App ID and REST API Key fields are required.', 'onesignal-free-web-push-notifications' ); ?></em></p>
 			  </div>
 			  <?php
             }
@@ -584,7 +586,7 @@ class OneSignal_Admin
             {
                 ?>
 			  <div class="error notice onesignal-error-notice">
-				  <p><strong>OneSignal Push:</strong> <em>cURL is not installed on this server. cURL is required to send notifications. Please make sure cURL is installed on your server before continuing.</em></p>
+				  <p><strong><?php esc_html_e( 'OneSignal Push:', 'onesignal-free-web-push-notifications' ); ?></strong> <em><?php esc_html_e( 'cURL is not installed on this server. cURL is required to send notifications. Please make sure cURL is installed on your server before continuing.', 'onesignal-free-web-push-notifications' ); ?></em></p>
 			  </div>
 			  <?php
             }
@@ -695,8 +697,14 @@ class OneSignal_Admin
 
             $time_to_wait = self::get_sending_rate_limit_wait_time();
             if ($time_to_wait > 0) {
+                /* translators: 1: Number of seconds to wait, 2: API rate limit in seconds */
+                $error_message = sprintf( 
+                    __( 'Please try again in %1$d seconds. Only one notification can be sent every %2$d seconds.', 'onesignal-free-web-push-notifications' ), 
+                    $time_to_wait, 
+                    ONESIGNAL_API_RATE_LIMIT_SECONDS 
+                );
                 set_transient('onesignal_transient_error', '<div class="error notice onesignal-error-notice">
-                    <p><strong>OneSignal Push:</strong><em> Please try again in '.$time_to_wait.' seconds. Only one notification can be sent every '.ONESIGNAL_API_RATE_LIMIT_SECONDS.' seconds.</em></p>
+                    <p><strong>' . esc_html__( 'OneSignal Push:', 'onesignal-free-web-push-notifications' ) . '</strong><em> ' . esc_html( $error_message ) . '</em></p>
                 </div>', 86400);
 
                 return;
@@ -824,7 +832,7 @@ class OneSignal_Admin
                         $site_title = qtrans_use($qtransLang, $site_title, false);
                         $notif_content = qtrans_use($qtransLang, $notif_content, false);
                     } catch (Exception $e) {
-                        return new WP_Error('err', __( "OneSignal: There was a problem sending a notification"));
+                        return new WP_Error('err', __( 'OneSignal: There was a problem sending a notification', 'onesignal-free-web-push-notifications' ));
                     }
                 }
 
@@ -921,7 +929,7 @@ class OneSignal_Admin
 
 		if (is_null($response)) {
             set_transient('onesignal_transient_error', '<div class="error notice onesignal-error-notice">
-                <p><strong>OneSignal Push:</strong><em> There was a problem sending your notification.</em></p>
+                <p><strong>' . esc_html__( 'OneSignal Push:', 'onesignal-free-web-push-notifications' ) . '</strong><em> ' . esc_html__( 'There was a problem sending your notification.', 'onesignal-free-web-push-notifications' ) . '</em></p>
                 </div>', 86400);
             return;
         }
@@ -939,13 +947,15 @@ class OneSignal_Admin
 
                 if ($status !== 200) {
                     if ($status !== 0) {
+                        /* translators: %d: HTTP status code */
+                        $error_message = sprintf( __( 'There was a %d error sending your notification.', 'onesignal-free-web-push-notifications' ), $status );
                         set_transient('onesignal_transient_error', '<div class="error notice onesignal-error-notice">
-                    <p><strong>OneSignal Push:</strong><em> There was a '.$status.' error sending your notification.</em></p>
+                    <p><strong>' . esc_html__( 'OneSignal Push:', 'onesignal-free-web-push-notifications' ) . '</strong><em> ' . esc_html( $error_message ) . '</em></p>
                 </div>', 86400);
                     } else {
                         // A 0 HTTP status code means the connection couldn't be established
                         set_transient('onesignal_transient_error', '<div class="error notice onesignal-error-notice">
-                    <p><strong>OneSignal Push:</strong><em> There was an error establishing a network connection. Please make sure outgoing network connections from cURL are allowed.</em></p>
+                    <p><strong>' . esc_html__( 'OneSignal Push:', 'onesignal-free-web-push-notifications' ) . '</strong><em> ' . esc_html__( 'There was an error establishing a network connection. Please make sure outgoing network connections from cURL are allowed.', 'onesignal-free-web-push-notifications' ) . '</em></p>
                 </div>', 86400);
                     }
                 } else {
@@ -954,10 +964,11 @@ class OneSignal_Admin
 
                         if ($config_show_notification_send_status_message) {
                               $app_id = $onesignal_wp_settings['app_id'];
-                              $delivery_link_text = ' Go to your app\'s Delivery tab to check sent messages: </em><a target="_blank" href="https://dashboard.onesignal.com/apps/' . $app_id . '/notifications">https://dashboard.onesignal.com/apps/' . $app_id . '/notifications</a><em>';
+                              $delivery_link_url = esc_url( 'https://dashboard.onesignal.com/apps/' . $app_id . '/notifications' );
+                              $delivery_link_text = ' ' . __( "Go to your app's Delivery tab to check sent messages:", 'onesignal-free-web-push-notifications' ) . '<a target="_blank" href="' . $delivery_link_url . '"> ' . $delivery_link_url . '</a>';
                               set_transient('onesignal_transient_success', '<div class="updated notice notice-success is-dismissible">
                 <div class="components-notice__content">
-                <p><strong>OneSignal Push:</strong><em> Successfully scheduled a notification.' . $delivery_link_text . '</em></p>
+                <p><strong>' . esc_html__( 'OneSignal Push:', 'onesignal-free-web-push-notifications' ) . '</strong><em> ' . esc_html__( 'Successfully scheduled a notification.', 'onesignal-free-web-push-notifications' ) . $delivery_link_text . '</em></p>
                 </div>
                   </div>', 86400);
                         }
@@ -972,7 +983,7 @@ class OneSignal_Admin
                 return $response;
             }
         } catch (Exception $e) {
-            return new WP_Error('err', __( "OneSignal: There was a problem sending a notification"));
+            return new WP_Error('err', __( 'OneSignal: There was a problem sending a notification', 'onesignal-free-web-push-notifications' ));
         } }
 
     public static function was_post_restored_from_trash($old_status, $new_status)

--- a/v2/onesignal-public.php
+++ b/v2/onesignal-public.php
@@ -430,7 +430,7 @@ class OneSignal_Public
         <amp-web-push-widget visibility="unsubscribed" layout="fixed" width="245" height="45">
             <button class="subscribe has-background has-text-color" on="tap:amp-web-push.subscribe">
                 <svg class="onesignal-bell-svg" xmlns="http://www.w3.org/2000/svg" width="99.7" height="99.7" viewBox="0 0 99.7 99.7" style="filter: drop-shadow(0 2px 4px rgba(34,36,38,0.35));; -webkit-filter: drop-shadow(0 2px 4px rgba(34,36,38,0.35));;"><circle class="background" cx="49.9" cy="49.9" r="49.9" style=""></circle><path class="foreground" d="M50.1 66.2H27.7s-2-.2-2-2.1c0-1.9 1.7-2 1.7-2s6.7-3.2 6.7-5.5S33 52.7 33 43.3s6-16.6 13.2-16.6c0 0 1-2.4 3.9-2.4 2.8 0 3.8 2.4 3.8 2.4 7.2 0 13.2 7.2 13.2 16.6s-1 11-1 13.3c0 2.3 6.7 5.5 6.7 5.5s1.7.1 1.7 2c0 1.8-2.1 2.1-2.1 2.1H50.1zm-7.2 2.3h14.5s-1 6.3-7.2 6.3-7.3-6.3-7.3-6.3z" style=""></path><ellipse class="stroke" cx="49.9" cy="49.9" rx="37.4" ry="36.9" style=""></ellipse></svg>
-                <span class="tooltiptext"><?php esc_html_e( 'Subscribe to notifications' ); ?></span>
+                <span class="tooltiptext"><?php esc_html_e( 'Subscribe to notifications', 'onesignal-free-web-push-notifications' ); ?></span>
             </button>
         </amp-web-push-widget>
 
@@ -438,7 +438,7 @@ class OneSignal_Public
         <amp-web-push-widget visibility="subscribed" layout="fixed" width="230" height="45">
             <button class="unsubscribe has-background has-text-color" on="tap:amp-web-push.unsubscribe">
                 <svg class="onesignal-bell-svg" xmlns="http://www.w3.org/2000/svg" width="99.7" height="99.7" viewBox="0 0 99.7 99.7" style="filter: drop-shadow(0 2px 4px rgba(34,36,38,0.35));; -webkit-filter: drop-shadow(0 2px 4px rgba(34,36,38,0.35));;"><circle class="background" cx="49.9" cy="49.9" r="49.9" style=""></circle><path class="foreground" d="M50.1 66.2H27.7s-2-.2-2-2.1c0-1.9 1.7-2 1.7-2s6.7-3.2 6.7-5.5S33 52.7 33 43.3s6-16.6 13.2-16.6c0 0 1-2.4 3.9-2.4 2.8 0 3.8 2.4 3.8 2.4 7.2 0 13.2 7.2 13.2 16.6s-1 11-1 13.3c0 2.3 6.7 5.5 6.7 5.5s1.7.1 1.7 2c0 1.8-2.1 2.1-2.1 2.1H50.1zm-7.2 2.3h14.5s-1 6.3-7.2 6.3-7.3-6.3-7.3-6.3z" style=""></path><ellipse class="stroke" cx="49.9" cy="49.9" rx="37.4" ry="36.9" style=""></ellipse></svg>
-                <span class="tooltiptext"><?php esc_html_e( 'Your\'e subscribed to notifications' ); ?></span>
+                <span class="tooltiptext"><?php esc_html_e( "You're subscribed to notifications", 'onesignal-free-web-push-notifications' ); ?></span>
             </button>
         </amp-web-push-widget>
         <?php

--- a/v2/onesignal-widget.php
+++ b/v2/onesignal-widget.php
@@ -5,18 +5,18 @@ defined( 'ABSPATH' ) or die('This page may not be accessed directly.');
 class OneSignalWidget extends WP_Widget {
   
 	function __construct() {
-    parent::__construct('OneSignalWidget', 'OneSignal', array( 'description' => 'Subscribe to notifications'));
+    parent::__construct('OneSignalWidget', 'OneSignal', array( 'description' => __( 'Subscribe to notifications', 'onesignal-free-web-push-notifications' ) ));
 	}
   
     // Admin editor
 	function form($instance) {
-    $title = ! empty( $instance['title'] ) ? $instance['title'] : 'Follow';
-    $text = ! empty( $instance['text'] ) ? $instance['text'] : 'Subscribe to notifications';
+    $title = ! empty( $instance['title'] ) ? $instance['title'] : __( 'Follow', 'onesignal-free-web-push-notifications' );
+    $text  = ! empty( $instance['text'] ) ? $instance['text'] : __( 'Subscribe to notifications', 'onesignal-free-web-push-notifications' );
 		?>
 		<p>
-		<label for="<?php echo esc_attr($this->get_field_id( 'title' )); ?>"><?php esc_attr_e( 'Title:' ); ?></label> 
+		<label for="<?php echo esc_attr($this->get_field_id( 'title' )); ?>"><?php esc_attr_e( 'Title:', 'onesignal-free-web-push-notifications' ); ?></label> 
 		<input class="widefat" id="<?php echo esc_attr($this->get_field_id( 'title' )); ?>" name="<?php echo esc_attr($this->get_field_name( 'title' )); ?>" type="text" value="<?php echo esc_attr( $title ); ?>">
-    		<label for="<?php echo esc_attr($this->get_field_id( 'text' )); ?>"><?php esc_attr_e( 'Body:' ); ?></label> 
+    		<label for="<?php echo esc_attr($this->get_field_id( 'text' )); ?>"><?php esc_attr_e( 'Body:', 'onesignal-free-web-push-notifications' ); ?></label> 
 		<input class="widefat" id="<?php echo esc_attr($this->get_field_id( 'text' )); ?>" name="<?php echo esc_attr($this->get_field_name( 'text' )); ?>" type="text" value="<?php echo esc_attr( $text ); ?>">
 		</p>
 		<?php 

--- a/v2/views/config.php
+++ b/v2/views/config.php
@@ -4,7 +4,7 @@ defined('ABSPATH') or die('This page may not be accessed directly.');
 
 if (!OneSignalUtils::can_modify_plugin_settings()) {
   // Exit if the current user does not have permission
-  die('Insufficient permissions to access config page.');
+  die( esc_html__( 'Insufficient permissions to access config page.', 'onesignal-free-web-push-notifications' ) );
 }
 
 // The user is just viewing the config page; this page cannot be accessed directly
@@ -39,41 +39,42 @@ $onesignal_wp_settings = OneSignal::get_onesignal_settings();
   <div class="ui site onesignal container" id="content-container">
     <div class="ui menu">
       <span style="padding:0 20px 15px; color:#3A3DB2; font-weight:700;">
-          Migrate Settings to OneSignal.com<br><br>
-          <p style="font-size:1.15rem;font-weight:500">All OneSignal prompt configurations on this page are moving to OneSignal.com.</p>
-          <button type="button" class="ui medium teal button" onclick="window.open('https://documentation.onesignal.com/docs/wordpress','_blank');">Learn More</button>
+          <?php esc_html_e( 'Migrate Settings to OneSignal.com', 'onesignal-free-web-push-notifications' ); ?><br><br>
+          <p style="font-size:1.15rem;font-weight:500"><?php esc_html_e( 'All OneSignal prompt configurations on this page are moving to OneSignal.com.', 'onesignal-free-web-push-notifications' ); ?></p>
+          <button type="button" class="ui medium teal button" onclick="window.open('https://documentation.onesignal.com/docs/wordpress','_blank');"><?php esc_html_e( 'Learn More', 'onesignal-free-web-push-notifications' ); ?></button>
           <form method="post" action="" style="margin-bottom: 20px; margin-top: 20px;">
-            <p style="font-size:1.15rem;">Save your current settings to a txt file</p>
+            <p style="font-size:1.15rem;"><?php esc_html_e( 'Save your current settings to a txt file', 'onesignal-free-web-push-notifications' ); ?></p>
             <?php wp_nonce_field('onesignal_export_nonce'); ?>
             <input type="hidden" name="plugin_action" value="export_settings">
-            <button type="submit" class="ui medium button">Export Current Configuration</button>
+            <button type="submit" class="ui medium button"><?php esc_html_e( 'Export Current Configuration', 'onesignal-free-web-push-notifications' ); ?></button>
           </form>
-          <p style="font-size:1.15rem;">What do I have to do?</p>
-          <p style="font-size:1.15rem;font-weight:500">1. Open the <a href="https://dashboard.onesignal.com/" target="_blank">OneSignal.com dashboard</a></p>
-          <p style="font-size:1.15rem;font-weight:500">2. Go to your app Settings > Push & In-App > Web > Wordpress Plugin or Website Builder</p>
+          <p style="font-size:1.15rem;"><?php esc_html_e( 'What do I have to do?', 'onesignal-free-web-push-notifications' ); ?></p>
+          <?php /* translators: %1$s: opening anchor tag to OneSignal.com dashboard, %2$s: closing anchor tag */ ?>
+          <p style="font-size:1.15rem;font-weight:500"><?php echo sprintf( __( '1. Open the %1$sOneSignal.com dashboard%2$s', 'onesignal-free-web-push-notifications' ), '<a href="https://dashboard.onesignal.com/" target="_blank">', '</a>' ); ?></p>
+          <p style="font-size:1.15rem;font-weight:500"><?php esc_html_e( '2. Go to your app Settings > Push & In-App > Web > Wordpress Plugin or Website Builder', 'onesignal-free-web-push-notifications' ); ?></p>
           <span class="onesignal-error-notice">
-            ⚠️ <strong>IMPORTANT:</strong> Steps 3 and 4 must be completed consecutively and without delay to ensure uninterrupted functionality.
+            ⚠️ <strong><?php esc_html_e( 'IMPORTANT:', 'onesignal-free-web-push-notifications' ); ?></strong> <?php esc_html_e( 'Steps 3 and 4 must be completed consecutively and without delay to ensure uninterrupted functionality.', 'onesignal-free-web-push-notifications' ); ?>
           </span><br/><br/>
-          <p style="font-size:1.15rem;font-weight:500">3. Recreate the plugin settings from this screen on the OneSignal.com dashboard (e.g. configure prompt options, subscription bell, etc...). Click Save.</p>
-          <p style="font-size:1.15rem;font-weight:500">4. Click "Migration Completed", below as soon as you have saved your configuration in the OneSignal.com dashboard.</p>
+          <p style="font-size:1.15rem;font-weight:500"><?php esc_html_e( '3. Recreate the plugin settings from this screen on the OneSignal.com dashboard (e.g. configure prompt options, subscription bell, etc...). Click Save.', 'onesignal-free-web-push-notifications' ); ?></p>
+          <p style="font-size:1.15rem;font-weight:500"><?php esc_html_e( '4. Click "Migration Completed", below as soon as you have saved your configuration in the OneSignal.com dashboard.', 'onesignal-free-web-push-notifications' ); ?></p>
           <form method="post" action="" class="pull-right" id="onesignal-migration-form" style="margin: 10px;">
               <?php wp_nonce_field('onesignal_migration_nonce'); ?>
               <input type="hidden" name="plugin_action" value="complete_migration">
-              <button type="button" class="ui medium purple-button" id="confirm-migration-button">Migration Completed</button>
+              <button type="button" class="ui medium purple-button" id="confirm-migration-button"><?php esc_html_e( 'Migration Completed', 'onesignal-free-web-push-notifications' ); ?></button>
           </form>
           <!-- Modal -->
           <div id="migration-confirmation-modal" class="ui modal">
-              <div class="header">Confirm Migration</div>
+              <div class="header"><?php esc_html_e( 'Confirm Migration', 'onesignal-free-web-push-notifications' ); ?></div>
               <div class="content">
                 <span class="onesignal-error-notice">
-                  This action is irreversible.
+                  <?php esc_html_e( 'This action is irreversible.', 'onesignal-free-web-push-notifications' ); ?>
                 </span><br/><br/>
-                  <p>By confirming the migration, you confirm that you have configured your prompt settings on the OneSignal.com dashboard.</p>
-                  <p>Are you sure you want to mark the plugin as migrated?</p>
+                  <p><?php esc_html_e( 'By confirming the migration, you confirm that you have configured your prompt settings on the OneSignal.com dashboard.', 'onesignal-free-web-push-notifications' ); ?></p>
+                  <p><?php esc_html_e( 'Are you sure you want to mark the plugin as migrated?', 'onesignal-free-web-push-notifications' ); ?></p>
               </div>
               <div class="actions">
-                  <button class="ui cancel button">Cancel</button>
-                  <button class="ui approve button" id="confirm-migration-submit" style="background-color:#E54B4D">Confirm</button>
+                  <button class="ui cancel button"><?php esc_html_e( 'Cancel', 'onesignal-free-web-push-notifications' ); ?></button>
+                  <button class="ui approve button" id="confirm-migration-submit" style="background-color:#E54B4D"><?php esc_html_e( 'Confirm', 'onesignal-free-web-push-notifications' ); ?></button>
               </div>
           </div>
 
@@ -81,8 +82,8 @@ $onesignal_wp_settings = OneSignal::get_onesignal_settings();
       </div>
       <div class="ui menu">
         <span style="padding-bottom:15px; padding-left:20px; color:#E54B4D; font-weight:700;">
-          ⭐ Appreciate OneSignal?
-          <a style="margin-left:15px;" href="https://wordpress.org/support/plugin/onesignal-free-web-push-notifications/reviews/#new-post" target="_blank">Leave us a review →	</a>
+          ⭐ <?php esc_html_e( 'Appreciate OneSignal?', 'onesignal-free-web-push-notifications' ); ?>
+          <a style="margin-left:15px;" href="https://wordpress.org/support/plugin/onesignal-free-web-push-notifications/reviews/#new-post" target="_blank"><?php esc_html_e( 'Leave us a review →', 'onesignal-free-web-push-notifications' ); ?></a>
         </span>
       </div>
   </div>
@@ -95,19 +96,19 @@ $onesignal_wp_settings = OneSignal::get_onesignal_settings();
         <div class="ui dividing header">
           <i class="setting icon"></i>
           <div class="content">
-            Account Settings
+            <?php esc_html_e( 'Account Settings', 'onesignal-free-web-push-notifications' ); ?>
           </div>
         </div>
         <div class="ui borderless shadowless segment">
           <div class="field">
             <div class="ui toggle checkbox">
               <input type="checkbox" name="is_site_https" <?php if ($onesignal_wp_settings['is_site_https_firsttime'] === 'unset') { echo "data-unset=\"true\""; }  if ($onesignal_wp_settings['is_site_https']) { echo "checked"; }  ?>>
-              <label>My site uses an HTTPS connection (SSL)<i class="tiny circular help icon link" role="popup" data-html="<p>Check this if your site uses HTTPS:</p><img src='<?php echo esc_url(ONESIGNAL_PLUGIN_URL."views/images/settings/https-url.png") ?>' width=619>" data-variation="flowing"></i></label>
+              <label><?php esc_html_e( 'My site uses an HTTPS connection (SSL)', 'onesignal-free-web-push-notifications' ); ?><i class="tiny circular help icon link" role="popup" data-html="<p><?php esc_attr_e( 'Check this if your site uses HTTPS:', 'onesignal-free-web-push-notifications' ); ?></p><img src='<?php echo esc_url(ONESIGNAL_PLUGIN_URL."views/images/settings/https-url.png") ?>' width=619>" data-variation="flowing"></i></label>
             </div>
           </div>
           <div class="ui inline subdomain-http nag">
             <span class="title">
-              This option is disabled when your current URL begins with <code>http://</code>. Please access this page using <code>https://</code> to enable this option.
+              <?php echo wp_kses_post( __( 'This option is disabled when your current URL begins with <code>http://</code>. Please access this page using <code>https://</code> to enable this option.', 'onesignal-free-web-push-notifications' ) ); ?>
             </span>
             <i class="close icon"></i>
           </div>
@@ -119,46 +120,47 @@ $onesignal_wp_settings = OneSignal::get_onesignal_settings();
                      (OneSignalUtils::url_contains_parameter(ONESIGNAL_URI_REVEAL_PROJECT_NUMBER))
                    ): ?>
           <div class="field">
-            <label>Google Project Number<i class="tiny circular help icon link" role="popup" data-title="Google Project Number" data-content="Your Google Project Number. Do NOT change this as it can cause all existing subscribers to become unreachable." data-variation="wide"></i></label>
-            <p class="hidden danger-label" data-target="[name=gcm_sender_id]">WARNING: Changing this causes all existing subscribers to become unreachable. Please do not change unless instructed to do so!</p>
+            <label><?php esc_html_e( 'Google Project Number', 'onesignal-free-web-push-notifications' ); ?><i class="tiny circular help icon link" role="popup" data-title="<?php esc_attr_e( 'Google Project Number', 'onesignal-free-web-push-notifications' ); ?>" data-content="<?php esc_attr_e( 'Your Google Project Number. Do NOT change this as it can cause all existing subscribers to become unreachable.', 'onesignal-free-web-push-notifications' ); ?>" data-variation="wide"></i></label>
+            <p class="hidden danger-label" data-target="[name=gcm_sender_id]"><?php esc_html_e( 'WARNING: Changing this causes all existing subscribers to become unreachable. Please do not change unless instructed to do so!', 'onesignal-free-web-push-notifications' ); ?></p>
             <input type="text" name="gcm_sender_id" placeholder="#############" value="<?php echo esc_attr($onesignal_wp_settings['gcm_sender_id']); ?>">
           </div>
           <?php endif; ?>
           <div class="field">
-            <label>App ID<i class="tiny circular help icon link" role="popup" data-title="App ID" data-content="Your 36 character alphanumeric app ID. You can find this in App Settings > Keys & IDs." data-variation="wide"></i></label>
+            <label><?php esc_html_e( 'App ID', 'onesignal-free-web-push-notifications' ); ?><i class="tiny circular help icon link" role="popup" data-title="<?php esc_attr_e( 'App ID', 'onesignal-free-web-push-notifications' ); ?>" data-content="<?php esc_attr_e( 'Your 36 character alphanumeric app ID. You can find this in App Settings > Keys & IDs.', 'onesignal-free-web-push-notifications' ); ?>" data-variation="wide"></i></label>
             <input type="text" name="app_id" placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx" value="<?php echo esc_attr($onesignal_wp_settings['app_id']); ?>">
           </div>
           <div class="field">
-            <label>REST API Key<i class="tiny circular help icon link" role="popup" data-title="Rest API Key" data-content="Your 48 character alphanumeric REST API Key. You can find this in App Settings > Keys & IDs." data-variation="wide"></i></label>
+            <label><?php esc_html_e( 'REST API Key', 'onesignal-free-web-push-notifications' ); ?><i class="tiny circular help icon link" role="popup" data-title="<?php esc_attr_e( 'Rest API Key', 'onesignal-free-web-push-notifications' ); ?>" data-content="<?php esc_attr_e( 'Your 48 character alphanumeric REST API Key. You can find this in App Settings > Keys & IDs.', 'onesignal-free-web-push-notifications' ); ?>" data-variation="wide"></i></label>
             <input type="text" name="app_rest_api_key" placeholder="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" value="<?php echo esc_attr(OneSignal::maskedRestApiKey($onesignal_wp_settings['app_rest_api_key'])); ?>">
           </div>
           <div class="field subdomain-feature">
-            <label>OneSignal Label<i class="tiny circular help icon link" role="popup" data-title="Subdomain" data-content="The label you chose for your site. You can find this in Step 2. Wordpress Site Setup" data-variation="wide"></i></label>
+            <label><?php esc_html_e( 'OneSignal Label', 'onesignal-free-web-push-notifications' ); ?><i class="tiny circular help icon link" role="popup" data-title="<?php esc_attr_e( 'Subdomain', 'onesignal-free-web-push-notifications' ); ?>" data-content="<?php esc_attr_e( 'The label you chose for your site. You can find this in Step 2. Wordpress Site Setup', 'onesignal-free-web-push-notifications' ); ?>" data-variation="wide"></i></label>
             <input type="text" name="subdomain" placeholder="example" value="<?php echo esc_attr($onesignal_wp_settings['subdomain']); ?>">
-            <div class="callout info">Once your site is public, <strong>do not change your label</strong>. If you do, users will receive duplicate notifications.</div>
+            <div class="callout info"><?php echo wp_kses_post( __( 'Once your site is public, <strong>do not change your label</strong>. If you do, users will receive duplicate notifications.', 'onesignal-free-web-push-notifications' ) ); ?></div>
           </div>
           <div class="field">
-            <label>Safari Web ID<i class="tiny circular help icon link" role="popup" data-title="Safari Web ID" data-content="Your Safari Web ID. You can find this on Setup > Safari Push > Step 5." data-variation="wide"></i></label>
+            <label><?php esc_html_e( 'Safari Web ID', 'onesignal-free-web-push-notifications' ); ?><i class="tiny circular help icon link" role="popup" data-title="<?php esc_attr_e( 'Safari Web ID', 'onesignal-free-web-push-notifications' ); ?>" data-content="<?php esc_attr_e( 'Your Safari Web ID. You can find this on Setup > Safari Push > Step 5.', 'onesignal-free-web-push-notifications' ); ?>" data-variation="wide"></i></label>
             <input type="text" name="safari_web_id" placeholder="web.com.example" value="<?php echo esc_attr($onesignal_wp_settings['safari_web_id']); ?>">
           </div>
         </div>
         <div class="ui dividing header">
           <i class="desktop icon"></i>
           <div class="content">
-            Sent Notification Settings
+            <?php esc_html_e( 'Sent Notification Settings', 'onesignal-free-web-push-notifications' ); ?>
           </div>
         </div>
         <div class="ui borderless shadowless segment">
           <div class="field">
             <div class="ui toggle checkbox">
               <input type="checkbox" name="showNotificationIconFromPostThumbnail" value="true" <?php if ($onesignal_wp_settings['showNotificationIconFromPostThumbnail']) { echo "checked"; } ?>>
-              <label>Use the post's featured image for the notification icon<i class="tiny circular help icon link" role="popup" data-title="Use post featured image for notification icon" data-content="If checked, use the post's featured image in the notification icon (small icon).  Chrome and Firefox Desktop supported." data-variation="wide"></i></label>
+              <label><?php esc_html_e( "Use the post's featured image for the notification icon", 'onesignal-free-web-push-notifications' ); ?><i class="tiny circular help icon link" role="popup" data-title="<?php esc_attr_e( 'Use post featured image for notification icon', 'onesignal-free-web-push-notifications' ); ?>" data-content="<?php esc_attr_e( "If checked, use the post's featured image in the notification icon (small icon).  Chrome and Firefox Desktop supported.", 'onesignal-free-web-push-notifications' ); ?>" data-variation="wide"></i></label>
             </div>
           </div>
           <div class="field">
             <div class="ui toggle checkbox">
               <input type="checkbox" name="showNotificationImageFromPostThumbnail" value="true" <?php if ($onesignal_wp_settings['showNotificationImageFromPostThumbnail']) { echo "checked"; } ?>>
-              <label>Use the post's featured image for Chrome's large notification image<i class="tiny circular help icon link" role="popup" data-title="Use post featured image for notification image (Chrome only)" data-html="<p>If checked, use the post's featured image in the notification large image (Chrome only). See <a target='docs' href='https://documentation.onesignal.com/docs/web-push-notification-icons#section-image'>our documentation on web push images</a>.</p>" data-variation="wide"></i></label>
+              <?php /* translators: %1$s: opening anchor tag to OneSignal documentation on web push images, %2$s: closing anchor tag */ ?>
+              <label><?php esc_html_e( "Use the post's featured image for Chrome's large notification image", 'onesignal-free-web-push-notifications' ); ?><i class="tiny circular help icon link" role="popup" data-title="<?php esc_attr_e( 'Use post featured image for notification image (Chrome only)', 'onesignal-free-web-push-notifications' ); ?>" data-html="<p><?php echo esc_attr( sprintf( __( "If checked, use the post's featured image in the notification large image (Chrome only). See %1$sour documentation on web push images%2$s.", 'onesignal-free-web-push-notifications' ), "<a target='docs' href='https://documentation.onesignal.com/docs/web-push-notification-icons#section-image'>", '</a>' ) ); ?></p>" data-variation="wide"></i></label>
             </div>
           </div>
           <div class="field">
@@ -191,7 +193,7 @@ $onesignal_wp_settings = OneSignal::get_onesignal_settings();
                         $onesignal_wp_settings['persist_notifications'] === "platform-default")) {
                           echo "selected";
                     }
-                  ?>>Yes
+                  ?>><?php esc_html_e( 'Yes', 'onesignal-free-web-push-notifications' ); ?>
               </option>
               <option
                 value="yes-except-notification-manager-platforms"
@@ -200,7 +202,7 @@ $onesignal_wp_settings = OneSignal::get_onesignal_settings();
                         $onesignal_wp_settings['persist_notifications'] === "yes-except-notification-manager-platforms")) {
                           echo "selected";
                     }
-                  ?>>Yes on Mac OS X. No on other platforms.
+                  ?>><?php esc_html_e( 'Yes on Mac OS X. No on other platforms.', 'onesignal-free-web-push-notifications' ); ?>
               </option>
               <option
                 value="yes-all"
@@ -209,7 +211,7 @@ $onesignal_wp_settings = OneSignal::get_onesignal_settings();
                         $onesignal_wp_settings['persist_notifications'] === "yes-all")) {
                           echo "selected";
                     }
-                  ?>>No
+                  ?>><?php esc_html_e( 'No', 'onesignal-free-web-push-notifications' ); ?>
               </option>
             </select>
           </div>
@@ -227,7 +229,7 @@ $onesignal_wp_settings = OneSignal::get_onesignal_settings();
         <div class="ui dividing header">
           <i class="alarm outline icon"></i>
           <div class="content">
-            Prompt Settings & Subscription Bell
+            <?php esc_html_e( 'Prompt Settings & Subscription Bell', 'onesignal-free-web-push-notifications' ); ?>
           </div>
         </div>
         <div class="ui borderless shadowless segment">
@@ -450,7 +452,7 @@ $onesignal_wp_settings = OneSignal::get_onesignal_settings();
           <div class="ui dividing header">
             <i class="external icon"></i>
             <div class="content">
-              Prompt Customization
+            <?php esc_html_e( 'Prompt Customization', 'onesignal-free-web-push-notifications' ); ?>
             </div>
           </div>
           <div style="display:flex; flex-wrap: wrap; align-items: center;">
@@ -510,7 +512,7 @@ $onesignal_wp_settings = OneSignal::get_onesignal_settings();
         <div class="ui dividing header">
           <i class="birthday outline icon"></i>
           <div class="content">
-            Welcome Notification Settings
+            <?php esc_html_e( 'Welcome Notification Settings', 'onesignal-free-web-push-notifications' ); ?>
           </div>
         </div>
         <div class="ui borderless shadowless segment" style="position: relative;">
@@ -540,7 +542,7 @@ $onesignal_wp_settings = OneSignal::get_onesignal_settings();
         <div class="ui dividing header">
           <i class="wizard icon"></i>
           <div class="content">
-            Automatic Notification Settings
+            <?php esc_html_e( 'Automatic Notification Settings', 'onesignal-free-web-push-notifications' ); ?>
           </div>
         </div>
         <div class="ui borderless shadowless segment">
@@ -560,7 +562,7 @@ $onesignal_wp_settings = OneSignal::get_onesignal_settings();
         <div class="ui dividing header">
           <i class="area chart icon"></i>
           <div class="content">
-            UTM Tracking Settings
+            <?php esc_html_e( 'UTM Tracking Settings', 'onesignal-free-web-push-notifications' ); ?>
           </div>
         </div>
         <div class="ui borderless shadowless segment">
@@ -572,7 +574,7 @@ $onesignal_wp_settings = OneSignal::get_onesignal_settings();
         <div class="ui dividing header">
           <i class="lab icon"></i>
           <div class="content">
-            Advanced Settings
+            <?php esc_html_e( 'Advanced Settings', 'onesignal-free-web-push-notifications' ); ?>
           </div>
         </div>
         <div class="ui borderless shadowless segment">
@@ -608,10 +610,10 @@ $onesignal_wp_settings = OneSignal::get_onesignal_settings();
           </div>
         </div>
     </div>
-    <button class="ui large teal button" type="submit">Save</button>
+    <button class="ui large teal button" type="submit"><?php esc_html_e( 'Save', 'onesignal-free-web-push-notifications' ); ?></button>
     <div class="ui inline validation nag">
         <span class="title">
-          Your OneSignal subdomain cannot be empty or less than 4 characters. Use the same one you entered on the platform settings at onesignal.com.
+          <?php esc_html_e( 'Your OneSignal subdomain cannot be empty or less than 4 characters. Use the same one you entered on the platform settings at onesignal.com.', 'onesignal-free-web-push-notifications' ); ?>
         </span>
       <i class="close icon"></i>
     </div>

--- a/v3/onesignal-admin/onesignal-admin.php
+++ b/v3/onesignal-admin/onesignal-admin.php
@@ -8,7 +8,14 @@ add_action('admin_menu', 'onesignal_admin_menu');
 
 function onesignal_admin_menu()
 {
-  add_menu_page('OneSignal - Push Notifications', 'OneSignal', 'manage_options', 'onesignal-admin-page.php', 'onesignal_admin_page', 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAwIiBoZWlnaHQ9IjMwMCIgdmlld0JveD0iMCAwIDMwMCAzMDAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik0xNDkuNzAyIDAuMDAwMjg4MzI0QzY2Ljk0NDQgMC4xNjEyMDYgLTAuNDY4ODA1IDY4LjEwODkgMC4wMDI0NTU4NSAxNTAuODY3QzAuNDE2MjQ2IDIyOC4xNTkgNTkuMzU4MyAyOTEuNjEzIDEzNC43NiAyOTkuMjIyQzEzNSAyOTkuMjQ2IDEzNS4yNDMgMjk5LjIxOSAxMzUuNDczIDI5OS4xNDRDMTM1LjcwMiAyOTkuMDY4IDEzNS45MTMgMjk4Ljk0NSAxMzYuMDkyIDI5OC43ODJDMTM2LjI3MSAyOTguNjIgMTM2LjQxNCAyOTguNDIxIDEzNi41MTEgMjk4LjJDMTM2LjYwOCAyOTcuOTc5IDEzNi42NTggMjk3LjczOSAxMzYuNjU2IDI5Ny40OThWMTQ5Ljk5OUgxMjUuMDM2QzEyNC41NzkgMTQ5Ljk5OSAxMjQuMTQgMTQ5LjgxNyAxMjMuODE3IDE0OS40OTRDMTIzLjQ5MyAxNDkuMTcxIDEyMy4zMTIgMTQ4LjczMiAxMjMuMzEyIDE0OC4yNzVWMTI1LjAyMkMxMjMuMzEyIDEyNC41NjUgMTIzLjQ5MyAxMjQuMTI2IDEyMy44MTcgMTIzLjgwM0MxMjQuMTQgMTIzLjQ4IDEyNC41NzkgMTIzLjI5OCAxMjUuMDM2IDEyMy4yOThIMTYxLjYyMkMxNjIuMDc5IDEyMy4yOTggMTYyLjUxOCAxMjMuNDggMTYyLjg0MSAxMjMuODAzQzE2My4xNjQgMTI0LjEyNiAxNjMuMzQ2IDEyNC41NjUgMTYzLjM0NiAxMjUuMDIyVjI5Ny40OThDMTYzLjM0NSAyOTcuNzM5IDE2My4zOTQgMjk3Ljk3OCAxNjMuNDkxIDI5OC4xOThDMTYzLjU4OCAyOTguNDE5IDE2My43MyAyOTguNjE3IDE2My45MDggMjk4Ljc4QzE2NC4wODcgMjk4Ljk0MiAxNjQuMjk3IDI5OS4wNjYgMTY0LjUyNiAyOTkuMTQyQzE2NC43NTQgMjk5LjIxOCAxNjQuOTk3IDI5OS4yNDUgMTY1LjIzNyAyOTkuMjIyQzI0MC45MiAyOTEuNTg0IDMwMCAyMjcuNjk0IDMwMCAxNDkuOTk5QzMwMCA2Ny4wNTcyIDIzMi42NzkgLTAuMTYwNjMgMTQ5LjcwMiAwLjAwMDI4ODMyNFpNMTkyLjM2OSAyNjUuODAzQzE5Mi4xMDkgMjY1Ljg5NSAxOTEuODMgMjY1LjkyMyAxOTEuNTU3IDI2NS44ODVDMTkxLjI4NCAyNjUuODQ3IDE5MS4wMjMgMjY1Ljc0NCAxOTAuNzk4IDI2NS41ODVDMTkwLjU3MyAyNjUuNDI1IDE5MC4zODkgMjY1LjIxNCAxOTAuMjYzIDI2NC45NjlDMTkwLjEzNiAyNjQuNzI0IDE5MC4wNyAyNjQuNDUyIDE5MC4wNyAyNjQuMTc2VjIzOS41NTZDMTkwLjA3MSAyMzkuMDY2IDE5MC4yMTEgMjM4LjU4NyAxOTAuNDczIDIzOC4xNzRDMTkwLjczNiAyMzcuNzYxIDE5MS4xMSAyMzcuNDMxIDE5MS41NTMgMjM3LjIyMkMyMDguMDI0IDIyOS4zNTkgMjIxLjkzNSAyMTYuOTk2IDIzMS42NzcgMjAxLjU2MkMyNDEuNDIgMTg2LjEyNyAyNDYuNTk3IDE2OC4yNTEgMjQ2LjYxIDE0OS45OTlDMjQ2LjYxIDk2LjIyMzYgMjAyLjQ0OSA1Mi41NzQ2IDE0OC40OTUgNTMuNDAyMUM5Ny4xNzQgNTQuMTgzNyA1NS4wNzY3IDk1LjU1NjkgNTMuNDM4OCAxNDYuODU1QzUyLjgzOTkgMTY1LjYzNSA1Ny43MjQ4IDE4NC4xODIgNjcuNDk2MyAyMDAuMjMxQzc3LjI2NzcgMjE2LjI3OSA5MS41MDI3IDIyOS4xMzMgMTA4LjQ2MSAyMzcuMjIyQzEwOC45MDUgMjM3LjQzMSAxMDkuMjggMjM3Ljc2MSAxMDkuNTQzIDIzOC4xNzRDMTA5LjgwNyAyMzguNTg3IDEwOS45NDggMjM5LjA2NiAxMDkuOTUgMjM5LjU1NlYyNjQuMTgyQzEwOS45NSAyNjQuNDU4IDEwOS44ODQgMjY0LjczIDEwOS43NTcgMjY0Ljk3NUMxMDkuNjMgMjY1LjIyIDEwOS40NDcgMjY1LjQzMSAxMDkuMjIxIDI2NS41OUMxMDguOTk2IDI2NS43NSAxMDguNzM2IDI2NS44NTMgMTA4LjQ2MyAyNjUuODkxQzEwOC4xODkgMjY1LjkyOSAxMDcuOTExIDI2NS45IDEwNy42NTEgMjY1LjgwOEM2MC4xMjg0IDI0OC4zNzcgMjYuMjE0OSAyMDIuNDcgMjYuNzAzNCAxNDguODVDMjcuMzA2OCA4MS44Njc0IDgyLjAyNDggMjcuMjE4NCAxNDkuMDMgMjYuNzAxMkMyMTcuNDYgMjYuMTcyNSAyNzMuMjk5IDgxLjY4OTIgMjczLjI5OSAxNDkuOTk5QzI3My4yOTkgMjAzLjExOSAyMzkuNTM1IDI0OC40OTggMTkyLjM2OSAyNjUuODAzWiIgZmlsbD0iI0U1NEI0RCIvPgo8L3N2Zz4K', 81);
+  add_menu_page(
+    __( 'OneSignal - Push Notifications', 'onesignal-free-web-push-notifications' ),
+    __( 'OneSignal', 'onesignal-free-web-push-notifications' ),
+    'manage_options',
+    'onesignal-admin-page.php',
+    'onesignal_admin_page',
+    'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAwIiBoZWlnaHQ9IjMwMCIgdmlld0JveD0iMCAwIDMwMCAzMDAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik0xNDkuNzAyIDAuMDAwMjg4MzI0QzY2Ljk0NDQgMC4xNjEyMDYgLTAuNDY4ODA1IDY4LjEwODkgMC4wMDI0NTU4NSAxNTAuODY3QzAuNDE2MjQ2IDIyOC4xNTkgNTkuMzU4MyAyOTEuNjEzIDEzNC43NiAyOTkuMjIyQzEzNSAyOTkuMjQ2IDEzNS4yNDMgMjk5LjIxOSAxMzUuNDczIDI5OS4xNDRDMTM1LjcwMiAyOTkuMDY4IDEzNS45MTMgMjk4Ljk0NSAxMzYuMDkyIDI5OC43ODJDMTM2LjI3MSAyOTguNjIgMTM2LjQxNCAyOTguNDIxIDEzNi41MTEgMjk4LjJDMTM2LjYwOCAyOTcuOTc5IDEzNi42NTggMjk3LjczOSAxMzYuNjU2IDI5Ny40OThWMTQ5Ljk5OUgxMjUuMDM2QzEyNC41NzkgMTQ5Ljk5OSAxMjQuMTQgMTQ5LjgxNyAxMjMuODE3IDE0OS40OTRDMTIzLjQ5MyAxNDkuMTcxIDEyMy4zMTIgMTQ4LjczMiAxMjMuMzEyIDE0OC4yNzVWMTI1LjAyMkMxMjMuMzEyIDEyNC41NjUgMTIzLjQ5MyAxMjQuMTI2IDEyMy44MTcgMTIzLjgwM0MxMjQuMTQgMTIzLjQ4IDEyNC41NzkgMTIzLjI5OCAxMjUuMDM2IDEyMy4yOThIMTYxLjYyMkMxNjIuMDc5IDEyMy4yOTggMTYyLjUxOCAxMjMuNDggMTYyLjg0MSAxMjMuODAzQzE2My4xNjQgMTI0LjEyNiAxNjMuMzQ2IDEyNC41NjUgMTYzLjM0NiAxMjUuMDIyVjI5Ny40OThDMTYzLjM0NSAyOTcuNzM5IDE2My4zOTQgMjk3Ljk3OCAxNjMuNDkxIDI5OC4xOThDMTYzLjU4OCAyOTguNDE5IDE2My43MyAyOTguNjE3IDE2My45MDggMjk4Ljc4QzE2NC4wODcgMjk4Ljk0MiAxNjQuMjk3IDI5OS4wNjYgMTY0LjUyNiAyOTkuMTQyQzE2NC43NTQgMjk5LjIxOCAxNjQuOTk3IDI5OS4yNDUgMTY1LjIzNyAyOTkuMjIyQzI0MC45MiAyOTEuNTg0IDMwMCAyMjcuNjk0IDMwMCAxNDkuOTk5QzMwMCA2Ny4wNTcyIDIzMi42NzkgLTAuMTYwNjMgMTQ5LjcwMiAwLjAwMDI4ODMyNFpNMTkyLjM2OSAyNjUuODAzQzE5Mi4xMDkgMjY1Ljg5NSAxOTEuODMgMjY1LjkyMyAxOTEuNTU3IDI2NS44ODVDMTkxLjI4NCAyNjUuODQ3IDE5MS4wMjMgMjY1Ljc0NCAxOTAuNzk4IDI2NS41ODVDMTkwLjU3MyAyNjUuNDI1IDE5MC4zODkgMjY1LjIxNCAxOTAuMjYzIDI2NC45NjlDMTkwLjEzNiAyNjQuNzI0IDE5MC4wNyAyNjQuNDUyIDE5MC4wNyAyNjQuMTc2VjIzOS41NTZDMTkwLjA3MSAyMzkuMDY2IDE5MC4yMTEgMjM4LjU4NyAxOTAuNDczIDIzOC4xNzRDMTkwLjczNiAyMzcuNzYxIDE5MS4xMSAyMzcuNDMxIDE5MS41NTMgMjM3LjIyMkMyMDguMDI0IDIyOS4zNTkgMjIxLjkzNSAyMTYuOTk2IDIzMS42NzcgMjAxLjU2MkMyNDEuNDIgMTg2LjEyNyAyNDYuNTk3IDE2OC4yNTEgMjQ2LjYxIDE0OS45OTlDMjQ2LjYxIDk2LjIyMzYgMjAyLjQ0OSA1Mi41NzQ2IDE0OC40OTUgNTMuNDAyMUM5Ny4xNzQgNTQuMTgzNyA1NS4wNzY3IDk1LjU1NjkgNTMuNDM4OCAxNDYuODU1QzUyLjgzOTkgMTY1LjYzNSA1Ny43MjQ4IDE4NC4xODIgNjcuNDk2MyAyMDAuMjMxQzc3LjI2NzcgMjE2LjI3OSA5MS41MDI3IDIyOS4xMzMgMTA4LjQ2MSAyMzcuMjIyQzEwOC45MDUgMjM3LjQzMSAxMDkuMjggMjM3Ljc2MSAxMDkuNTQzIDIzOC4xNzRDMTA5LjgwNyAyMzguNTg3IDEwOS45NDggMjM5LjA2NiAxMDkuOTUgMjM5LjU1NlYyNjQuMTgyQzEwOS45NSAyNjQuNDU4IDEwOS44ODQgMjY0LjczIDEwOS43NTcgMjY0Ljk3NUMxMDkuNjMgMjY1LjIyIDEwOS40NDcgMjY1LjQzMSAxMDkuMjIxIDI2NS41OUMxMDguOTk2IDI2NS43NSAxMDguNzM2IDI2NS44NTMgMTA4LjQ2MyAyNjUuODkxQzEwOC4xODkgMjY1LjkyOSAxMDcuOTExIDI2NS45IDEwNy42NTEgMjY1LjgwOEM2MC4xMjg0IDI0OC4zNzcgMjYuMjE0OSAyMDIuNDcgMjYuNzAzNCAxNDguODVDMjcuMzA2OCA4MS44Njc0IDgyLjAyNDggMjcuMjE4NCAxNDkuMDMgMjYuNzAxMkMyMTcuNDYgMjYuMTcyNSAyNzMuMjk5IDgxLjY4OTIgMjczLjI5OSAxNDkuOTk5QzI3My4yOTkgMjAzLjExOSAyMzkuNTM1IDI0OC40OTggMTkyLjM2OSAyNjUuODAzWiIgZmlsbD0iI0U1NEI0RCIvPgo8L3N2Zz4K',
+    81);
 }
 
 // Load style for page
@@ -128,13 +135,13 @@ function onesignal_admin_page()
 ?>
   <header><img src="<?php echo plugins_url('/images/onesignal.svg', __FILE__); ?>"></header>
   <div class="os-content">
-    <h2>Settings</h2>
+    <h2><?php esc_html_e( 'Settings', 'onesignal-free-web-push-notifications' ); ?></h2>
     <?php
     if ($is_new_install) {
     ?>
     <div style="margin-bottom: 20px;">
       <span style="margin-bottom:35px;color:#E54B4D; font-weight:700;">
-        <a href="https://documentation.onesignal.com/docs/wordpress" target="_blank">Getting Started →	</a>
+        <a href="https://documentation.onesignal.com/docs/wordpress" target="_blank"><?php esc_html_e( 'Getting Started →	', 'onesignal-free-web-push-notifications' ); ?></a>
       </span>
     </div>
     <?php
@@ -142,7 +149,7 @@ function onesignal_admin_page()
     ?>
     <form method="post">
       <?php wp_nonce_field('onesignal_v3_save_settings', 'onesignal_v3_settings_nonce'); ?>
-      <label for="appid">OneSignal App ID</label>
+      <label for="appid"><?php esc_html_e( 'OneSignal App ID', 'onesignal-free-web-push-notifications' ); ?></label>
       <div class="input-with-icon">
         <input type="text" id="appid" name="onesignal_app_id"
               value="<?php echo esc_attr(get_option('OneSignalWPSetting')['app_id'] ?? ''); ?>" />
@@ -154,17 +161,18 @@ function onesignal_admin_page()
         </span>
       </div>
 
-      <label for="apikey">OneSignal REST API Key
+      <label for="apikey"><?php esc_html_e( 'OneSignal REST API Key', 'onesignal-free-web-push-notifications' ); ?>
           <?php
           $apiKey = get_option('OneSignalWPSetting')['app_rest_api_key'] ?? '';
           if (!empty($apiKey)) {
               // Display the API key type
-              echo '<span class="api-key-badge api-key-type-'.strtolower(onesignal_get_api_key_type()).'">' . onesignal_get_api_key_type() . ' API Key</span>';
+              /* translators: %s: API key type (Legacy or Rich) */
+              echo '<span class="api-key-badge api-key-type-'.strtolower(onesignal_get_api_key_type()).'">' . esc_html( sprintf( __( '%s API Key', 'onesignal-free-web-push-notifications' ), onesignal_get_api_key_type() ) ) . '</span>';
           }
           ?>
       </label>
       <div class="input-with-icon">
-        <input type="password" id="apikey" name="onesignal_rest_api_key" placeholder="Enter a REST API Key to update" />
+        <input type="password" id="apikey" name="onesignal_rest_api_key" placeholder="<?php esc_attr_e( 'Enter a REST API Key to update', 'onesignal-free-web-push-notifications' ); ?>" />
         <span class="validation-icon">
           <?php
           $apiKey = get_option('OneSignalWPSetting')['app_rest_api_key'] ?? '';
@@ -185,15 +193,16 @@ function onesignal_admin_page()
             // Hide the rest of the key with asterisks
             $hiddenKey = str_repeat('*', strlen($apiKey) - 4) . $lastFour;
 
-            echo 'Current Key: ' . $hiddenKey;
+            /* translators: %s: Masked API key */
+            echo esc_html( sprintf( __( 'Current Key: %s', 'onesignal-free-web-push-notifications' ), $hiddenKey ) );
         } else {
-            echo '❌ Please enter your REST API Key';
+            echo '❌ ' . esc_html__( 'Please enter your REST API Key', 'onesignal-free-web-push-notifications' );
         }
         ?>
       </p>
-      <p class="help-text">The REST API Key is hidden for security reasons. Enter a new key to update.</p>
+      <p class="help-text"><?php esc_html_e( 'The REST API Key is hidden for security reasons. Enter a new key to update.', 'onesignal-free-web-push-notifications' ); ?></p>
 
-      <h3>Advanced Settings</h3>
+      <h3><?php esc_html_e( 'Advanced Settings', 'onesignal-free-web-push-notifications' ); ?></h3>
       <div class="ui borderless shadowless segment">
       <?php
         $oneSignalSettings = get_option('OneSignalWPSetting');
@@ -205,8 +214,8 @@ function onesignal_admin_page()
         }
         ?>
         <div class="field utm-params">
-            <label>Additional Notification URL Parameters</label>
-            <div class="help" aria-label="More information">
+            <label><?php esc_html_e( 'Additional Notification URL Parameters', 'onesignal-free-web-push-notifications' ); ?></label>
+            <div class="help" aria-label="<?php esc_attr_e( 'More information', 'onesignal-free-web-push-notifications' ); ?>">
               <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
                 <g fill="currentColor">
                   <path d="M8 0a8 8 0 108 8 8.009 8.009 0 00-8-8zm0 12.667a1 1 0 110-2 1 1 0 010 2zm1.067-4.054a.667.667 0 00-.4.612.667.667 0 01-1.334 0 2 2 0 011.2-1.834A1.333 1.333 0 106.667 6.17a.667.667 0 01-1.334 0 2.667 2.667 0 113.734 2.444z"></path>
@@ -231,8 +240,8 @@ function onesignal_admin_page()
         ?>
       <br>
       <div class="field custom-post-types">
-        <label>Additional Custom Post Types for Automatic Notifications Created From Plugins</label>
-        <div class="help" aria-label="More information">
+        <label><?php esc_html_e( 'Additional Custom Post Types for Automatic Notifications Created From Plugins', 'onesignal-free-web-push-notifications' ); ?></label>
+        <div class="help" aria-label="<?php esc_attr_e( 'More information', 'onesignal-free-web-push-notifications' ); ?>">
           <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
             <g fill="currentColor">
               <path d="M8 0a8 8 0 108 8 8.009 8.009 0 00-8-8zm0 12.667a1 1 0 110-2 1 1 0 010 2zm1.067-4.054a.667.667 0 00-.4.612.667.667 0 01-1.334 0 2 2 0 011.2-1.834A1.333 1.333 0 106.667 6.17a.667.667 0 01-1.334 0 2.667 2.667 0 113.734 2.444z"></path>
@@ -251,7 +260,7 @@ function onesignal_admin_page()
           <input id="auto-send" type="checkbox" name="onesignal_auto_send"
                  <?php echo (!empty($settings['notification_on_post'])) ? 'checked' : ''; ?>>
           <span class="checkbox"></span>
-          Automatically send notifications when a post is published
+          <?php esc_html_e( 'Automatically send notifications when a post is published', 'onesignal-free-web-push-notifications' ); ?>
         </label>
       </div>
 
@@ -261,7 +270,7 @@ function onesignal_admin_page()
           <input id="auto-send-post-update" type="checkbox" name="onesignal_auto_send_post_update"
                  <?php echo (!empty($settings['notification_on_post_update'])) ? 'checked' : ''; ?>>
           <span class="checkbox"></span>
-          Automatically send notifications when a post is updated
+          <?php esc_html_e( 'Automatically send notifications when a post is updated', 'onesignal-free-web-push-notifications' ); ?>
         </label>
       </div>
 
@@ -271,7 +280,7 @@ function onesignal_admin_page()
           <input id="auto-send-pages" type="checkbox" name="onesignal_auto_send_pages"
                  <?php echo (!empty($settings['notification_on_page'])) ? 'checked' : ''; ?>>
           <span class="checkbox"></span>
-          Automatically send notifications when a page is published
+          <?php esc_html_e( 'Automatically send notifications when a page is published', 'onesignal-free-web-push-notifications' ); ?>
         </label>
       </div>
 
@@ -281,7 +290,7 @@ function onesignal_admin_page()
           <input id="auto-send-page-update" type="checkbox" name="onesignal_auto_send_page_update"
                  <?php echo (!empty($settings['notification_on_page_update'])) ? 'checked' : ''; ?>>
           <span class="checkbox"></span>
-          Automatically send notifications when a page is updated
+          <?php esc_html_e( 'Automatically send notifications when a page is updated', 'onesignal-free-web-push-notifications' ); ?>
         </label>
       </div>
 
@@ -292,9 +301,9 @@ function onesignal_admin_page()
             <?php echo (!empty($settings['notification_on_post_from_plugin'])) ? 'checked' : ''; ?>
             >
             <span class="checkbox"></span>
-            Automatically send a push notification when I publish a post from 3<sup>rd</sup> party plugins
+            <?php echo wp_kses( __( 'Automatically send a push notification when I publish a post from 3<sup>rd</sup> party plugins', 'onesignal-free-web-push-notifications' ), array( 'sup' => array() ) ); ?>
         </label>
-        <div class="help" aria-label="More information">
+        <div class="help" aria-label="<?php esc_attr_e( 'More information', 'onesignal-free-web-push-notifications' ); ?>">
           <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
             <g fill="currentColor">
               <path d="M8 0a8 8 0 108 8 8.009 8.009 0 00-8-8zm0 12.667a1 1 0 110-2 1 1 0 010 2zm1.067-4.054a.667.667 0 00-.4.612.667.667 0 01-1.334 0 2 2 0 011.2-1.834A1.333 1.333 0 106.667 6.17a.667.667 0 01-1.334 0 2.667 2.667 0 113.734 2.444z"></path>
@@ -302,7 +311,7 @@ function onesignal_admin_page()
           </svg>
         </div>
         <div class="information" style="display: none;">
-          <p>If checked, when a post is created outside of WordPress's editor, a push notification will automatically be sent. Must be the built-in WordPress post type 'post' and the post must be published.</p>
+          <p><?php esc_html_e( "If checked, when a post is created outside of WordPress's editor, a push notification will automatically be sent. Must be the built-in WordPress post type 'post' and the post must be published.", 'onesignal-free-web-push-notifications' ); ?></p>
         </div>
       </div>
 
@@ -312,9 +321,9 @@ function onesignal_admin_page()
           <input id="send-to-mobile" type="checkbox" name="onesignal_send_to_mobile"
                  <?php echo (!empty($settings['send_to_mobile_platforms'])) ? 'checked' : ''; ?>>
           <span class="checkbox"></span>
-          Send notification to Mobile app subscribers
+          <?php esc_html_e( 'Send notification to Mobile app subscribers', 'onesignal-free-web-push-notifications' ); ?>
         </label>
-        <div class="help" aria-label="More information">
+        <div class="help" aria-label="<?php esc_attr_e( 'More information', 'onesignal-free-web-push-notifications' ); ?>">
           <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
             <g fill="currentColor">
               <path d="M8 0a8 8 0 108 8 8.009 8.009 0 00-8-8zm0 12.667a1 1 0 110-2 1 1 0 010 2zm1.067-4.054a.667.667 0 00-.4.612.667.667 0 01-1.334 0 2 2 0 011.2-1.834A1.333 1.333 0 106.667 6.17a.667.667 0 01-1.334 0 2.667 2.667 0 113.734 2.444z"></path>

--- a/v3/onesignal-metabox/onesignal-metabox.php
+++ b/v3/onesignal-metabox/onesignal-metabox.php
@@ -12,7 +12,7 @@ function onesignal_add_metabox()
   if (onesignal_is_post_type_allowed($current_post_type)) {
     add_meta_box(
       'onesignal_metabox', // metabox ID
-      'OneSignal Push Notifications', // title
+      __( 'OneSignal Push Notifications', 'onesignal-free-web-push-notifications' ), // title
       'onesignal_metabox', // callback function
     );
   }
@@ -79,12 +79,17 @@ function onesignal_metabox($post)
        }
        echo $os_update_checked ? 'checked' : '';
        ?>>
-Send notification when <?php echo $post_type === 'page' ? 'page' : 'post'; ?> is <?php echo $is_new_post ? 'published' : 'updated'; ?>
+<?php
+$notification_type = $post_type === 'page' ? __( 'page', 'onesignal-free-web-push-notifications' ) : __( 'post', 'onesignal-free-web-push-notifications' );
+$notification_action = $is_new_post ? __( 'published', 'onesignal-free-web-push-notifications' ) : __( 'updated', 'onesignal-free-web-push-notifications' );
+/* translators: 1: post type (page/post), 2: action (published/updated) */
+echo esc_html( sprintf( __( 'Send notification when %1$s is %2$s', 'onesignal-free-web-push-notifications' ), $notification_type, $notification_action ) );
+?>
 </label>
   <div id="os_options">
-    <label for="os_segment">Send to segment</label>
+    <label for="os_segment"><?php esc_html_e( 'Send to segment', 'onesignal-free-web-push-notifications' ); ?></label>
     <select name="os_segment" id="os_segment">
-    <option value="All">All</option>
+    <option value="All"><?php esc_html_e( 'All', 'onesignal-free-web-push-notifications' ); ?></option>
     <?php
     if ($json && is_array($json->segments)) {
         foreach ($json->segments as $segment) {
@@ -94,22 +99,22 @@ Send notification when <?php echo $post_type === 'page' ? 'page' : 'post'; ?> is
             }
         }
     } else {
-        echo '<option disabled>No segments available</option>';
+        echo '<option disabled>' . esc_html__( 'No segments available', 'onesignal-free-web-push-notifications' ) . '</option>';
     }
     ?>
 </select>
     <hr>
     <label for="os_customise">
-      <input type="checkbox" name="os_customise" id="os_customise" <?php echo isset($os_meta['os_customise']) && $os_meta['os_customise'] === 'on' ? 'checked' : '' ?>>Customize notification content</label>
+      <input type="checkbox" name="os_customise" id="os_customise" <?php echo isset($os_meta['os_customise']) && $os_meta['os_customise'] === 'on' ? 'checked' : '' ?>><?php esc_html_e( 'Customize notification content', 'onesignal-free-web-push-notifications' ); ?></label>
     <div id="os_customisations" style="<?php echo isset($os_meta['os_customise']) && $os_meta['os_customise'] === 'on' ? 'display:block;' : 'display:none;'; ?>">
-      <label for="os_title">Notification title</label>
+      <label for="os_title"><?php esc_html_e( 'Notification title', 'onesignal-free-web-push-notifications' ); ?></label>
       <input type="text" name="os_title" id="os_title" value="<?php echo esc_attr(isset($os_meta['os_title']) ? $os_meta['os_title'] : ''); ?>" disabled>
-      <label for="os_content">Notification content</label>
+      <label for="os_content"><?php esc_html_e( 'Notification content', 'onesignal-free-web-push-notifications' ); ?></label>
       <input type="text" name="os_content" id="os_content" value="<?php echo esc_attr(isset($os_meta['os_content']) ? $os_meta['os_content'] : ''); ?>" disabled>
     </div>
     <?php if (get_option('OneSignalWPSetting')['send_to_mobile_platforms'] == 1) : ?>
       <hr>
-      <label for="os_mobile_url">Mobile URL</label>
+      <label for="os_mobile_url"><?php esc_html_e( 'Mobile URL', 'onesignal-free-web-push-notifications' ); ?></label>
       <input type="text" name="os_mobile_url" id="os_mobile_url" value="<?php echo esc_attr(isset($os_meta['os_mobile_url']) ? $os_meta['os_mobile_url'] : ''); ?>">
     <?php endif; ?>
   </div>


### PR DESCRIPTION
### Motivation

We are about to use thisplugin in a customers website, when a colleague asked why the checkbox, about whether or not to send notifications when publishing a post, is in english.
So I went ahead and wrapped these parts in WordPress' translation functions, but since I would already have to create a PR, I took the opportunity to make the entire plugin translation-ready.

### Changes

This PR adds WordPress translation functions to most, if not all, user-facing strings across both the v2 and v3 codebases:

#### Files Modified:
- plugin index file:
  - added text domain to header
  - migration notice
- V2:
  - `v2/onesignal-admin.php` - meta boxes, admin notices,error messages
  - `v2/views/config.php` - all settings page content _(that was a big one)_
  - `v2/onesignal-public.php` - amp widget subscription messages
  - `v2/onesignal-widget.php` - labels and defaults
- V3
  - `v3/onesignal-admin/onesignal-admin.php` - albels and messages
  - `v3/onesignal-metabox/onesignal-metabox.php` - meta box content

### Implementation Details

- Text domain: `onesignal-free-web-push-notifications`
   _same as plugin folder name when installed_
- Uses appropriate WordPress translation functions (`esc_attr__()` etc.)
- Adds translator comments for strings with placeholders
- Fixed a typo or two

### WordPress.org Integration

Once merged, community translators can add translations that will automatically be distributedto users without requiring translation files in the repo.

### Testing

All strings were wrapped according to WordPress' best practices. The plugin should work identically in English, but is now ready for translation into any language.

---

**Note:** I tried to catch all user-facing strings, but if I missed any, lmk!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-WordPress-Plugin/384)
<!-- Reviewable:end -->
