### PR TITLE
feat: notification show feedback

### DIFF
--- a/tests/integration/TestAPIIntegration.php
+++ b/tests/integration/TestAPIIntegration.php
@@ -161,6 +161,12 @@ class Test_OneSignal_API_Integration extends TestCase {
                 return ($thing instanceof WP_Error);
             });
 
+        WP_Mock::userFunction('get_current_user_id')
+            ->andReturn(1);
+
+        WP_Mock::userFunction('set_transient')
+            ->andReturn(true);
+
         // Mock WordPress hook functions
         WP_Mock::userFunction('has_filter')
             ->andReturnUsing(function($tag, $function_to_check = false) {

--- a/tests/integration/TestAPIIntegration.php
+++ b/tests/integration/TestAPIIntegration.php
@@ -609,4 +609,200 @@ class Test_OneSignal_API_Integration extends TestCase {
         $this->assertStringStartsWith('onesignal/wordpress/', $header_value, 'Header should start with onesignal/wordpress/');
         $this->assertMatchesRegularExpression('/^onesignal\/wordpress\/\d{6}$/', $header_value, 'Header should match pattern onesignal/wordpress/XXYYZZ');
     }
+
+    /**
+     * Helper to capture the last value stored via set_transient.
+     */
+    private function captureTransient(): array {
+        $captured = [];
+        WP_Mock::userFunction('set_transient')
+            ->andReturnUsing(function ($key, $value) use (&$captured) {
+                $captured = $value;
+                return true;
+            });
+        return $captured;
+    }
+
+    /**
+     * Test store_send_notice stores status='success' and the notification ID as detail.
+     */
+    public function test_store_notice_success_status() {
+        $captured = [];
+        WP_Mock::userFunction('set_transient')
+            ->andReturnUsing(function ($key, $value) use (&$captured) {
+                $captured = $value;
+                return true;
+            });
+
+        $this->mock_http_request('https://onesignal.com/api/v1/notifications', [
+            'response' => ['code' => 200],
+            'body'     => json_encode(['id' => 'notif-success-123']),
+        ]);
+
+        $post = (object) [
+            'ID'            => 1001,
+            'post_title'    => 'Success Notice Test',
+            'post_date'     => '2024-01-15 10:00:00',
+            'post_date_gmt' => '2024-01-15 10:00:00',
+            'post_type'     => 'post',
+        ];
+
+        onesignal_create_notification($post);
+
+        $this->assertSame('success', $captured['status']);
+        $this->assertSame('notif-success-123', $captured['detail']);
+    }
+
+    /**
+     * Test store_send_notice stores status='scheduled' for a future post date.
+     */
+    public function test_store_notice_scheduled_status() {
+        $captured = [];
+        WP_Mock::userFunction('set_transient')
+            ->andReturnUsing(function ($key, $value) use (&$captured) {
+                $captured = $value;
+                return true;
+            });
+
+        $this->mock_http_request('https://onesignal.com/api/v1/notifications', [
+            'response' => ['code' => 200],
+            'body'     => json_encode(['id' => 'notif-scheduled-456']),
+        ]);
+
+        $post = (object) [
+            'ID'            => 1002,
+            'post_title'    => 'Scheduled Notice Test',
+            'post_date'     => '2030-01-01 10:00:00',
+            'post_date_gmt' => '2030-01-01 10:00:00',
+            'post_type'     => 'post',
+        ];
+
+        onesignal_create_notification($post);
+
+        $this->assertSame('scheduled', $captured['status']);
+        $this->assertSame('notif-scheduled-456', $captured['detail']);
+    }
+
+    /**
+     * Test store_send_notice stores status='warning' with the translated error string
+     * when the API returns 200 but no recipients (string error in errors[0]).
+     */
+    public function test_store_notice_warning_status_with_string_error() {
+        $captured = [];
+        WP_Mock::userFunction('set_transient')
+            ->andReturnUsing(function ($key, $value) use (&$captured) {
+                $captured = $value;
+                return true;
+            });
+
+        $this->mock_http_request('https://onesignal.com/api/v1/notifications', [
+            'response' => ['code' => 200],
+            'body'     => json_encode(['id' => '', 'errors' => ['All included players are not subscribed']]),
+        ]);
+
+        $post = (object) [
+            'ID'            => 1003,
+            'post_title'    => 'Warning Notice Test',
+            'post_date'     => '2024-01-15 10:00:00',
+            'post_date_gmt' => '2024-01-15 10:00:00',
+            'post_type'     => 'post',
+        ];
+
+        onesignal_create_notification($post);
+
+        $this->assertSame('warning', $captured['status']);
+        // "players" → "subscriptions" translation should have been applied
+        $this->assertStringContainsString('subscriptions', $captured['detail']);
+        $this->assertStringNotContainsString('players', $captured['detail']);
+    }
+
+    /**
+     * Test store_send_notice stores status='warning' with the fallback message
+     * when the API returns 200 with no id and no usable errors array.
+     */
+    public function test_store_notice_warning_status_fallback_message() {
+        $captured = [];
+        WP_Mock::userFunction('set_transient')
+            ->andReturnUsing(function ($key, $value) use (&$captured) {
+                $captured = $value;
+                return true;
+            });
+
+        $this->mock_http_request('https://onesignal.com/api/v1/notifications', [
+            'response' => ['code' => 200],
+            'body'     => json_encode(['id' => '']),
+        ]);
+
+        $post = (object) [
+            'ID'            => 1004,
+            'post_title'    => 'Warning Fallback Test',
+            'post_date'     => '2024-01-15 10:00:00',
+            'post_date_gmt' => '2024-01-15 10:00:00',
+            'post_type'     => 'post',
+        ];
+
+        onesignal_create_notification($post);
+
+        $this->assertSame('warning', $captured['status']);
+        $this->assertSame('No eligible subscriptions found in the selected segment.', $captured['detail']);
+    }
+
+    /**
+     * Test store_send_notice stores status='error' and the WP_Error message as detail.
+     */
+    public function test_store_notice_error_status_on_wp_error() {
+        $captured = [];
+        WP_Mock::userFunction('set_transient')
+            ->andReturnUsing(function ($key, $value) use (&$captured) {
+                $captured = $value;
+                return true;
+            });
+
+        $error = new WP_Error('http_request_failed', 'Connection timeout');
+        $this->mock_http_request('https://onesignal.com/api/v1/notifications', $error);
+
+        $post = (object) [
+            'ID'            => 1005,
+            'post_title'    => 'WP Error Notice Test',
+            'post_date'     => '2024-01-15 10:00:00',
+            'post_date_gmt' => '2024-01-15 10:00:00',
+            'post_type'     => 'post',
+        ];
+
+        onesignal_create_notification($post);
+
+        $this->assertSame('error', $captured['status']);
+        $this->assertSame('Connection timeout', $captured['detail']);
+    }
+
+    /**
+     * Test store_send_notice stores status='error' and the API error string as detail
+     * when the API returns a non-200 response with a string errors[0].
+     */
+    public function test_store_notice_error_status_on_non_200() {
+        $captured = [];
+        WP_Mock::userFunction('set_transient')
+            ->andReturnUsing(function ($key, $value) use (&$captured) {
+                $captured = $value;
+                return true;
+            });
+
+        $this->mock_http_request('https://onesignal.com/api/v1/notifications', [
+            'response' => ['code' => 400, 'message' => 'Bad Request'],
+            'body'     => json_encode(['errors' => ['Invalid app_id']]),
+        ]);
+
+        $post = (object) [
+            'ID'            => 1006,
+            'post_title'    => 'Non-200 Error Notice Test',
+            'post_date'     => '2024-01-15 10:00:00',
+            'post_date_gmt' => '2024-01-15 10:00:00',
+            'post_type'     => 'post',
+        ];
+
+        onesignal_create_notification($post);
+
+        $this->assertSame('error', $captured['status']);
+        $this->assertSame('Invalid app_id', $captured['detail']);
+    }
 }

--- a/tests/integration/TestAPIIntegration.php
+++ b/tests/integration/TestAPIIntegration.php
@@ -20,6 +20,11 @@ class Test_OneSignal_API_Integration extends TestCase {
     private static $captured_request_args = array();
 
     /**
+     * Last value stored via set_transient, captured for status-branch assertions.
+     */
+    private array $lastTransient = [];
+
+    /**
      * Mock an HTTP request URL with a specific response
      * 
      * @param string $url The URL to mock
@@ -164,8 +169,12 @@ class Test_OneSignal_API_Integration extends TestCase {
         WP_Mock::userFunction('get_current_user_id')
             ->andReturn(1);
 
+        $this->lastTransient = [];
         WP_Mock::userFunction('set_transient')
-            ->andReturn(true);
+            ->andReturnUsing(function ($key, $value) {
+                $this->lastTransient = $value;
+                return true;
+            });
 
         // Mock WordPress hook functions
         WP_Mock::userFunction('has_filter')
@@ -611,29 +620,9 @@ class Test_OneSignal_API_Integration extends TestCase {
     }
 
     /**
-     * Helper to capture the last value stored via set_transient.
-     */
-    private function captureTransient(): array {
-        $captured = [];
-        WP_Mock::userFunction('set_transient')
-            ->andReturnUsing(function ($key, $value) use (&$captured) {
-                $captured = $value;
-                return true;
-            });
-        return $captured;
-    }
-
-    /**
      * Test store_send_notice stores status='success' and the notification ID as detail.
      */
     public function test_store_notice_success_status() {
-        $captured = [];
-        WP_Mock::userFunction('set_transient')
-            ->andReturnUsing(function ($key, $value) use (&$captured) {
-                $captured = $value;
-                return true;
-            });
-
         $this->mock_http_request('https://onesignal.com/api/v1/notifications', [
             'response' => ['code' => 200],
             'body'     => json_encode(['id' => 'notif-success-123']),
@@ -649,21 +638,14 @@ class Test_OneSignal_API_Integration extends TestCase {
 
         onesignal_create_notification($post);
 
-        $this->assertSame('success', $captured['status']);
-        $this->assertSame('notif-success-123', $captured['detail']);
+        $this->assertSame('success', $this->lastTransient['status']);
+        $this->assertSame('notif-success-123', $this->lastTransient['detail']);
     }
 
     /**
      * Test store_send_notice stores status='scheduled' for a future post date.
      */
     public function test_store_notice_scheduled_status() {
-        $captured = [];
-        WP_Mock::userFunction('set_transient')
-            ->andReturnUsing(function ($key, $value) use (&$captured) {
-                $captured = $value;
-                return true;
-            });
-
         $this->mock_http_request('https://onesignal.com/api/v1/notifications', [
             'response' => ['code' => 200],
             'body'     => json_encode(['id' => 'notif-scheduled-456']),
@@ -679,8 +661,8 @@ class Test_OneSignal_API_Integration extends TestCase {
 
         onesignal_create_notification($post);
 
-        $this->assertSame('scheduled', $captured['status']);
-        $this->assertSame('notif-scheduled-456', $captured['detail']);
+        $this->assertSame('scheduled', $this->lastTransient['status']);
+        $this->assertSame('notif-scheduled-456', $this->lastTransient['detail']);
     }
 
     /**
@@ -688,13 +670,6 @@ class Test_OneSignal_API_Integration extends TestCase {
      * when the API returns 200 but no recipients (string error in errors[0]).
      */
     public function test_store_notice_warning_status_with_string_error() {
-        $captured = [];
-        WP_Mock::userFunction('set_transient')
-            ->andReturnUsing(function ($key, $value) use (&$captured) {
-                $captured = $value;
-                return true;
-            });
-
         $this->mock_http_request('https://onesignal.com/api/v1/notifications', [
             'response' => ['code' => 200],
             'body'     => json_encode(['id' => '', 'errors' => ['All included players are not subscribed']]),
@@ -710,10 +685,10 @@ class Test_OneSignal_API_Integration extends TestCase {
 
         onesignal_create_notification($post);
 
-        $this->assertSame('warning', $captured['status']);
+        $this->assertSame('warning', $this->lastTransient['status']);
         // "players" → "subscriptions" translation should have been applied
-        $this->assertStringContainsString('subscriptions', $captured['detail']);
-        $this->assertStringNotContainsString('players', $captured['detail']);
+        $this->assertStringContainsString('subscriptions', $this->lastTransient['detail']);
+        $this->assertStringNotContainsString('players', $this->lastTransient['detail']);
     }
 
     /**
@@ -721,13 +696,6 @@ class Test_OneSignal_API_Integration extends TestCase {
      * when the API returns 200 with no id and no usable errors array.
      */
     public function test_store_notice_warning_status_fallback_message() {
-        $captured = [];
-        WP_Mock::userFunction('set_transient')
-            ->andReturnUsing(function ($key, $value) use (&$captured) {
-                $captured = $value;
-                return true;
-            });
-
         $this->mock_http_request('https://onesignal.com/api/v1/notifications', [
             'response' => ['code' => 200],
             'body'     => json_encode(['id' => '']),
@@ -743,21 +711,14 @@ class Test_OneSignal_API_Integration extends TestCase {
 
         onesignal_create_notification($post);
 
-        $this->assertSame('warning', $captured['status']);
-        $this->assertSame('No eligible subscriptions found in the selected segment.', $captured['detail']);
+        $this->assertSame('warning', $this->lastTransient['status']);
+        $this->assertSame('No eligible subscriptions found in the selected segment.', $this->lastTransient['detail']);
     }
 
     /**
      * Test store_send_notice stores status='error' and the WP_Error message as detail.
      */
     public function test_store_notice_error_status_on_wp_error() {
-        $captured = [];
-        WP_Mock::userFunction('set_transient')
-            ->andReturnUsing(function ($key, $value) use (&$captured) {
-                $captured = $value;
-                return true;
-            });
-
         $error = new WP_Error('http_request_failed', 'Connection timeout');
         $this->mock_http_request('https://onesignal.com/api/v1/notifications', $error);
 
@@ -771,8 +732,8 @@ class Test_OneSignal_API_Integration extends TestCase {
 
         onesignal_create_notification($post);
 
-        $this->assertSame('error', $captured['status']);
-        $this->assertSame('Connection timeout', $captured['detail']);
+        $this->assertSame('error', $this->lastTransient['status']);
+        $this->assertSame('Connection timeout', $this->lastTransient['detail']);
     }
 
     /**
@@ -780,13 +741,6 @@ class Test_OneSignal_API_Integration extends TestCase {
      * when the API returns a non-200 response with a string errors[0].
      */
     public function test_store_notice_error_status_on_non_200() {
-        $captured = [];
-        WP_Mock::userFunction('set_transient')
-            ->andReturnUsing(function ($key, $value) use (&$captured) {
-                $captured = $value;
-                return true;
-            });
-
         $this->mock_http_request('https://onesignal.com/api/v1/notifications', [
             'response' => ['code' => 400, 'message' => 'Bad Request'],
             'body'     => json_encode(['errors' => ['Invalid app_id']]),
@@ -802,7 +756,7 @@ class Test_OneSignal_API_Integration extends TestCase {
 
         onesignal_create_notification($post);
 
-        $this->assertSame('error', $captured['status']);
-        $this->assertSame('Invalid app_id', $captured['detail']);
+        $this->assertSame('error', $this->lastTransient['status']);
+        $this->assertSame('Invalid app_id', $this->lastTransient['detail']);
     }
 }

--- a/v3/onesignal-block-editor-notice.js
+++ b/v3/onesignal-block-editor-notice.js
@@ -85,6 +85,10 @@
                 },
               ]
             : [];
+        } else if (status === "warning") {
+          type = "warning";
+          message = "OneSignal: Push notification not sent: " + notificationId;
+          actions = [];
         } else {
           type = "error";
           message =

--- a/v3/onesignal-block-editor-notice.js
+++ b/v3/onesignal-block-editor-notice.js
@@ -36,9 +36,11 @@
   }
 
   function fetchAndDisplayNotice() {
+    var postId = select("core/editor").getCurrentPostId();
     var body = new URLSearchParams({
       action: "onesignal_get_send_notice",
       nonce: onesignalNotice.nonce,
+      post_id: postId,
     });
 
     fetch(onesignalNotice.ajaxUrl, {

--- a/v3/onesignal-block-editor-notice.js
+++ b/v3/onesignal-block-editor-notice.js
@@ -1,0 +1,78 @@
+(function () {
+    var subscribe = wp.data.subscribe;
+    var select = wp.data.select;
+    var dispatch = wp.data.dispatch;
+
+    var wasSaving = false;
+
+    var unsubscribe = subscribe(function () {
+        var editor = select('core/editor');
+        if (!editor) return;
+
+        var isSaving = editor.isSavingPost();
+        var isAutosave = editor.isAutosavingPost();
+        var isSavingNonAutosave = isSaving && !isAutosave;
+
+        // Detect the moment a non-autosave save transitions from in-progress to complete
+        if (wasSaving && !isSavingNonAutosave) {
+            wasSaving = false;
+            fetchAndDisplayNotice();
+        }
+
+        if (isSavingNonAutosave) {
+            wasSaving = true;
+        }
+    });
+
+    function buildDashboardUrl(notificationId) {
+        var appId = onesignalNotice.appId;
+        if (!appId || !notificationId) return '';
+        return 'https://dashboard.onesignal.com/apps/' + encodeURIComponent(appId) + '/push/' + encodeURIComponent(notificationId);
+    }
+
+    function fetchAndDisplayNotice() {
+        var body = new URLSearchParams({
+            action: 'onesignal_get_send_notice',
+            nonce: onesignalNotice.nonce,
+        });
+
+        fetch(onesignalNotice.ajaxUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: body.toString(),
+            credentials: 'same-origin',
+        })
+            .then(function (r) { return r.json(); })
+            .then(function (response) {
+                if (!response.success || !response.data) return;
+
+                var status = response.data.status;
+                var notificationId = response.data.detail;
+                var dashboardUrl = buildDashboardUrl(notificationId);
+                var type, message, actions;
+
+                if (status === 'success') {
+                    type = 'success';
+                    message = 'OneSignal: Push notification sent successfully.';
+                    actions = dashboardUrl ? [{ label: 'View in OneSignal Dashboard', url: dashboardUrl }] : [];
+                } else if (status === 'scheduled') {
+                    type = 'info';
+                    message = 'OneSignal: Push notification scheduled. If you change the scheduled post time in WordPress, the existing notification will be cancelled and a new one created.';
+                    actions = dashboardUrl ? [{ label: 'View scheduled notification in OneSignal Dashboard', url: dashboardUrl }] : [];
+                } else {
+                    type = 'error';
+                    message = 'OneSignal: Push notification failed to send: ' + notificationId;
+                    actions = [];
+                }
+
+                dispatch('core/notices').createNotice(type, message, {
+                    id: 'onesignal-send-notice',
+                    isDismissible: true,
+                    actions: actions,
+                });
+            })
+            .catch(function () {
+                // Silently ignore network errors
+            });
+    }
+})();

--- a/v3/onesignal-block-editor-notice.js
+++ b/v3/onesignal-block-editor-notice.js
@@ -1,78 +1,105 @@
 (function () {
-    var subscribe = wp.data.subscribe;
-    var select = wp.data.select;
-    var dispatch = wp.data.dispatch;
+  var subscribe = wp.data.subscribe;
+  var select = wp.data.select;
+  var dispatch = wp.data.dispatch;
 
-    var wasSaving = false;
+  var wasSaving = false;
 
-    var unsubscribe = subscribe(function () {
-        var editor = select('core/editor');
-        if (!editor) return;
+  var unsubscribe = subscribe(function () {
+    var editor = select("core/editor");
+    if (!editor) return;
 
-        var isSaving = editor.isSavingPost();
-        var isAutosave = editor.isAutosavingPost();
-        var isSavingNonAutosave = isSaving && !isAutosave;
+    var isSaving = editor.isSavingPost();
+    var isAutosave = editor.isAutosavingPost();
+    var isSavingNonAutosave = isSaving && !isAutosave;
 
-        // Detect the moment a non-autosave save transitions from in-progress to complete
-        if (wasSaving && !isSavingNonAutosave) {
-            wasSaving = false;
-            fetchAndDisplayNotice();
-        }
+    // Detect the moment a non-autosave save transitions from in-progress to complete
+    if (wasSaving && !isSavingNonAutosave) {
+      wasSaving = false;
+      fetchAndDisplayNotice();
+    }
 
-        if (isSavingNonAutosave) {
-            wasSaving = true;
-        }
+    if (isSavingNonAutosave) {
+      wasSaving = true;
+    }
+  });
+
+  function buildDashboardUrl(notificationId) {
+    var appId = onesignalNotice.appId;
+    if (!appId || !notificationId) return "";
+    return (
+      "https://dashboard.onesignal.com/apps/" +
+      encodeURIComponent(appId) +
+      "/push/" +
+      encodeURIComponent(notificationId)
+    );
+  }
+
+  function fetchAndDisplayNotice() {
+    var body = new URLSearchParams({
+      action: "onesignal_get_send_notice",
+      nonce: onesignalNotice.nonce,
     });
 
-    function buildDashboardUrl(notificationId) {
-        var appId = onesignalNotice.appId;
-        if (!appId || !notificationId) return '';
-        return 'https://dashboard.onesignal.com/apps/' + encodeURIComponent(appId) + '/push/' + encodeURIComponent(notificationId);
-    }
+    fetch(onesignalNotice.ajaxUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+      credentials: "same-origin",
+    })
+      .then(function (r) {
+        return r.json();
+      })
+      .then(function (response) {
+        if (!response.success || !response.data) return;
 
-    function fetchAndDisplayNotice() {
-        var body = new URLSearchParams({
-            action: 'onesignal_get_send_notice',
-            nonce: onesignalNotice.nonce,
+        var status = response.data.status;
+        var notificationId = response.data.detail;
+        var dashboardUrl = buildDashboardUrl(notificationId);
+        var type, message, actions;
+
+        if (status === "success") {
+          type = "success";
+          message = "OneSignal: Push notification sent successfully.";
+          actions = dashboardUrl
+            ? [
+                {
+                  label: "View in OneSignal Dashboard",
+                  onClick: function () {
+                    window.open(dashboardUrl, "_blank", "noopener,noreferrer");
+                  },
+                },
+              ]
+            : [];
+        } else if (status === "scheduled") {
+          type = "info";
+          message =
+            "OneSignal: Push notification scheduled. If you change the scheduled post time in WordPress, the existing notification will be cancelled and a new one created.";
+          actions = dashboardUrl
+            ? [
+                {
+                  label: "View scheduled notification in OneSignal Dashboard",
+                  onClick: function () {
+                    window.open(dashboardUrl, "_blank", "noopener,noreferrer");
+                  },
+                },
+              ]
+            : [];
+        } else {
+          type = "error";
+          message =
+            "OneSignal: Push notification failed to send: " + notificationId;
+          actions = [];
+        }
+
+        dispatch("core/notices").createNotice(type, message, {
+          id: "onesignal-send-notice",
+          isDismissible: true,
+          actions: actions,
         });
-
-        fetch(onesignalNotice.ajaxUrl, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body: body.toString(),
-            credentials: 'same-origin',
-        })
-            .then(function (r) { return r.json(); })
-            .then(function (response) {
-                if (!response.success || !response.data) return;
-
-                var status = response.data.status;
-                var notificationId = response.data.detail;
-                var dashboardUrl = buildDashboardUrl(notificationId);
-                var type, message, actions;
-
-                if (status === 'success') {
-                    type = 'success';
-                    message = 'OneSignal: Push notification sent successfully.';
-                    actions = dashboardUrl ? [{ label: 'View in OneSignal Dashboard', url: dashboardUrl }] : [];
-                } else if (status === 'scheduled') {
-                    type = 'info';
-                    message = 'OneSignal: Push notification scheduled. If you change the scheduled post time in WordPress, the existing notification will be cancelled and a new one created.';
-                    actions = dashboardUrl ? [{ label: 'View scheduled notification in OneSignal Dashboard', url: dashboardUrl }] : [];
-                } else {
-                    type = 'error';
-                    message = 'OneSignal: Push notification failed to send: ' + notificationId;
-                    actions = [];
-                }
-
-                dispatch('core/notices').createNotice(type, message, {
-                    id: 'onesignal-send-notice',
-                    isDismissible: true,
-                    actions: actions,
-                });
-            })
-            .catch(function () {
-                // Silently ignore network errors
-            });
-    }
+      })
+      .catch(function () {
+        // Silently ignore network errors
+      });
+  }
 })();

--- a/v3/onesignal-block-editor-notice.js
+++ b/v3/onesignal-block-editor-notice.js
@@ -1,17 +1,18 @@
 (function () {
-  var subscribe = wp.data.subscribe;
-  var select = wp.data.select;
-  var dispatch = wp.data.dispatch;
+  let subscribe = wp.data.subscribe;
+  let select = wp.data.select;
+  let dispatch = wp.data.dispatch;
 
-  var wasSaving = false;
+  let wasSaving = false;
 
-  var unsubscribe = subscribe(function () {
-    var editor = select("core/editor");
+  subscribe(function () {
+    let editor = select("core/editor");
     if (!editor) return;
 
-    var isSaving = editor.isSavingPost();
-    var isAutosave = editor.isAutosavingPost();
-    var isSavingNonAutosave = isSaving && !isAutosave;
+    let isSaving = editor.isSavingPost();
+    let isAutosave = editor.isAutosavingPost();
+    let isSavingMetaBoxes = editor.isSavingMetaBoxes ? editor.isSavingMetaBoxes() : false;
+    let isSavingNonAutosave = (isSaving && !isAutosave) || isSavingMetaBoxes;
 
     // Detect the moment a non-autosave save transitions from in-progress to complete
     if (wasSaving && !isSavingNonAutosave) {
@@ -25,7 +26,7 @@
   });
 
   function buildDashboardUrl(notificationId) {
-    var appId = onesignalNotice.appId;
+    let appId = onesignalNotice.appId;
     if (!appId || !notificationId) return "";
     return (
       "https://dashboard.onesignal.com/apps/" +
@@ -36,8 +37,8 @@
   }
 
   function fetchAndDisplayNotice() {
-    var postId = select("core/editor").getCurrentPostId();
-    var body = new URLSearchParams({
+    let postId = select("core/editor").getCurrentPostId();
+    let body = new URLSearchParams({
       action: "onesignal_get_send_notice",
       nonce: onesignalNotice.nonce,
       post_id: postId,
@@ -55,10 +56,10 @@
       .then(function (response) {
         if (!response.success || !response.data) return;
 
-        var status = response.data.status;
-        var notificationId = response.data.detail;
-        var dashboardUrl = buildDashboardUrl(notificationId);
-        var type, message, actions;
+        let status = response.data.status;
+        let detail = response.data.detail;
+        let dashboardUrl = buildDashboardUrl(detail);
+        let type, message, actions;
 
         if (status === "success") {
           type = "success";
@@ -89,12 +90,12 @@
             : [];
         } else if (status === "warning") {
           type = "warning";
-          message = "OneSignal: Push notification not sent: " + notificationId;
+          message = "OneSignal: Push notification not sent: " + detail;
           actions = [];
         } else {
           type = "error";
           message =
-            "OneSignal: Push notification failed to send: " + notificationId;
+            "OneSignal: Push notification failed to send: " + detail;
           actions = [];
         }
 

--- a/v3/onesignal-block-editor-notice.js
+++ b/v3/onesignal-block-editor-notice.js
@@ -11,7 +11,7 @@
 
     let isSaving = editor.isSavingPost();
     let isAutosave = editor.isAutosavingPost();
-    let isSavingMetaBoxes = editor.isSavingMetaBoxes ? editor.isSavingMetaBoxes() : false;
+    let isSavingMetaBoxes = wp.data.select("core/edit-post")?.isSavingMetaBoxes() ?? false;
     let isSavingNonAutosave = (isSaving && !isAutosave) || isSavingMetaBoxes;
 
     // Detect the moment a non-autosave save transitions from in-progress to complete

--- a/v3/onesignal-block-editor-notice.js
+++ b/v3/onesignal-block-editor-notice.js
@@ -76,8 +76,7 @@
             : [];
         } else if (status === "scheduled") {
           type = "info";
-          message =
-            "OneSignal: Push notification scheduled. If you change the scheduled post time in WordPress, the existing notification will be cancelled and a new one created.";
+          message = "OneSignal: Push notification scheduled. If you change the scheduled post time in WordPress, the existing notification will be cancelled and a new one created.";
           actions = dashboardUrl
             ? [
                 {
@@ -94,8 +93,7 @@
           actions = [];
         } else {
           type = "error";
-          message =
-            "OneSignal: Push notification failed to send: " + detail;
+          message = "OneSignal: Push notification failed to send: " + detail;
           actions = [];
         }
 

--- a/v3/onesignal-notification.php
+++ b/v3/onesignal-notification.php
@@ -130,7 +130,7 @@ function onesignal_create_notification($post, $notification_options = array())
     $response = wp_remote_post('https://onesignal.com/api/v1/notifications', $args);
     if (is_wp_error($response)) {
         error_log('API request failed: ' . $response->get_error_message());
-        onesignal_store_send_notice('error', $response->get_error_message());
+        onesignal_store_send_notice('error', $response->get_error_message(), $post->ID);
     } else {
         // Save the notification ID for potential future cancellation
         $response_code = wp_remote_retrieve_response_code($response);
@@ -141,9 +141,9 @@ function onesignal_create_notification($post, $notification_options = array())
             if (!empty($notification_id)) {
                 onesignal_save_notification_id($post->ID, $notification_id);
                 if (isset($fields['send_after'])) {
-                    onesignal_store_send_notice('scheduled', $notification_id);
+                    onesignal_store_send_notice('scheduled', $notification_id, $post->ID);
                 } else {
-                    onesignal_store_send_notice('success', $notification_id);
+                    onesignal_store_send_notice('success', $notification_id, $post->ID);
                 }
             } else {
                 // API returned 200 but empty id — no eligible subscribers
@@ -153,14 +153,17 @@ function onesignal_create_notification($post, $notification_options = array())
                 } else {
                     $detail = 'No eligible subscriptions found in the selected segment.';
                 }
-                onesignal_store_send_notice('warning', $detail);
+                onesignal_store_send_notice('warning', $detail, $post->ID);
             }
         } else {
             $response_body = wp_remote_retrieve_body($response);
             $response_data = json_decode($response_body, true);
-            $error_message = $response_data['errors'][0] ?? wp_remote_retrieve_response_message($response);
+            $errors = $response_data['errors'] ?? [];
+            $error_message = (is_array($errors) && isset($errors[0]) && is_string($errors[0]))
+                ? $errors[0]
+                : wp_remote_retrieve_response_message($response);
             error_log('API request failed with status ' . $response_code . ': ' . $error_message);
-            onesignal_store_send_notice('error', $error_message);
+            onesignal_store_send_notice('error', $error_message, $post->ID);
         }
     }
 }
@@ -169,9 +172,9 @@ function onesignal_create_notification($post, $notification_options = array())
  * Stores a notification send result in a short-lived user-scoped transient
  * so it can be displayed as an admin notice after the page redirect.
  */
-function onesignal_store_send_notice($status, $detail = '')
+function onesignal_store_send_notice($status, $detail = '', $post_id = 0)
 {
-    $key = 'onesignal_send_notice_' . get_current_user_id();
+    $key = 'onesignal_send_notice_' . get_current_user_id() . '_' . $post_id;
     set_transient($key, array('status' => $status, 'detail' => $detail), 60);
 }
 
@@ -180,6 +183,8 @@ function onesignal_store_send_notice($status, $detail = '')
  */
 function onesignal_display_send_notice()
 {
+    global $post;
+
     $screen = get_current_screen();
     // Only show on post edit screens
     if (!$screen || !in_array($screen->base, array('post', 'edit'), true)) {
@@ -193,7 +198,8 @@ function onesignal_display_send_notice()
         return;
     }
 
-    $key = 'onesignal_send_notice_' . get_current_user_id();
+    $post_id = $post ? $post->ID : 0;
+    $key = 'onesignal_send_notice_' . get_current_user_id() . '_' . $post_id;
     $notice = get_transient($key);
     if (!$notice) {
         return;
@@ -259,7 +265,8 @@ function onesignal_display_send_notice()
 function onesignal_ajax_get_send_notice()
 {
     check_ajax_referer('onesignal_notice_nonce', 'nonce');
-    $key = 'onesignal_send_notice_' . get_current_user_id();
+    $post_id = absint($_POST['post_id'] ?? 0);
+    $key = 'onesignal_send_notice_' . get_current_user_id() . '_' . $post_id;
     $notice = get_transient($key);
     if ($notice) {
         delete_transient($key);

--- a/v3/onesignal-notification.php
+++ b/v3/onesignal-notification.php
@@ -137,14 +137,23 @@ function onesignal_create_notification($post, $notification_options = array())
         if ($response_code === 200) {
             $response_body = wp_remote_retrieve_body($response);
             $response_data = json_decode($response_body, true);
-            if (!empty($response_data['id'])) {
-                onesignal_save_notification_id($post->ID, $response_data['id']);
-            }
             $notification_id = $response_data['id'] ?? '';
-            if (isset($fields['send_after'])) {
-                onesignal_store_send_notice('scheduled', $notification_id);
+            if (!empty($notification_id)) {
+                onesignal_save_notification_id($post->ID, $notification_id);
+                if (isset($fields['send_after'])) {
+                    onesignal_store_send_notice('scheduled', $notification_id);
+                } else {
+                    onesignal_store_send_notice('success', $notification_id);
+                }
             } else {
-                onesignal_store_send_notice('success', $notification_id);
+                // API returned 200 but empty id — no eligible subscribers
+                $errors = $response_data['errors'] ?? [];
+                if (is_array($errors) && isset($errors[0]) && is_string($errors[0])) {
+                    $detail = str_ireplace(['players', 'player'], ['subscriptions', 'subscription'], $errors[0]);
+                } else {
+                    $detail = 'No eligible subscriptions found in the selected segment.';
+                }
+                onesignal_store_send_notice('warning', $detail);
             }
         } else {
             $response_body = wp_remote_retrieve_body($response);
@@ -218,6 +227,13 @@ function onesignal_display_send_notice()
                 . $scheduled_link . ' '
                 . __('If you change the scheduled post time in WordPress, the existing notification will be cancelled and a new one created.', 'onesignal');
             $type = 'info';
+            break;
+        case 'warning':
+            $message = sprintf(
+                __('Push notification not sent: %s', 'onesignal'),
+                esc_html($notice['detail'])
+            );
+            $type = 'warning';
             break;
         case 'error':
         default:

--- a/v3/onesignal-notification.php
+++ b/v3/onesignal-notification.php
@@ -12,6 +12,15 @@ add_action('save_post', 'onesignal_handle_quick_edit_date_change', 10, 3);
 // Register handler to cancel scheduled notifications when posts are deleted
 add_action('wp_trash_post', 'onesignal_cancel_notification_on_post_delete');
 
+// Display admin notices after a notification send attempt (classic editor)
+add_action('admin_notices', 'onesignal_display_send_notice');
+
+// AJAX endpoint to serve pending notices to the block editor
+add_action('wp_ajax_onesignal_get_send_notice', 'onesignal_ajax_get_send_notice');
+
+// Enqueue block editor notice script
+add_action('enqueue_block_editor_assets', 'onesignal_enqueue_block_editor_notice');
+
 // Core function to create and send/schedule a notification
 function onesignal_create_notification($post, $notification_options = array())
 {
@@ -121,6 +130,7 @@ function onesignal_create_notification($post, $notification_options = array())
     $response = wp_remote_post('https://onesignal.com/api/v1/notifications', $args);
     if (is_wp_error($response)) {
         error_log('API request failed: ' . $response->get_error_message());
+        onesignal_store_send_notice('error', $response->get_error_message());
     } else {
         // Save the notification ID for potential future cancellation
         $response_code = wp_remote_retrieve_response_code($response);
@@ -130,8 +140,140 @@ function onesignal_create_notification($post, $notification_options = array())
             if (!empty($response_data['id'])) {
                 onesignal_save_notification_id($post->ID, $response_data['id']);
             }
+            $notification_id = $response_data['id'] ?? '';
+            if (isset($fields['send_after'])) {
+                onesignal_store_send_notice('scheduled', $notification_id);
+            } else {
+                onesignal_store_send_notice('success', $notification_id);
+            }
+        } else {
+            $response_body = wp_remote_retrieve_body($response);
+            $response_data = json_decode($response_body, true);
+            $error_message = $response_data['errors'][0] ?? wp_remote_retrieve_response_message($response);
+            error_log('API request failed with status ' . $response_code . ': ' . $error_message);
+            onesignal_store_send_notice('error', $error_message);
         }
     }
+}
+
+/**
+ * Stores a notification send result in a short-lived user-scoped transient
+ * so it can be displayed as an admin notice after the page redirect.
+ */
+function onesignal_store_send_notice($status, $detail = '')
+{
+    $key = 'onesignal_send_notice_' . get_current_user_id();
+    set_transient($key, array('status' => $status, 'detail' => $detail), 60);
+}
+
+/**
+ * Reads the stored transient and renders a WP admin notice, then deletes it.
+ */
+function onesignal_display_send_notice()
+{
+    $screen = get_current_screen();
+    // Only show on post edit screens
+    if (!$screen || !in_array($screen->base, array('post', 'edit'), true)) {
+        return;
+    }
+
+    // In the block editor, Gutenberg fetches the redirect page in the background
+    // after saving, which causes admin_notices to fire and consume the transient
+    // before the JS AJAX handler can read it. Let the JS handle it instead.
+    if ($screen->is_block_editor()) {
+        return;
+    }
+
+    $key = 'onesignal_send_notice_' . get_current_user_id();
+    $notice = get_transient($key);
+    if (!$notice) {
+        return;
+    }
+    delete_transient($key);
+
+    $app_id          = get_option('OneSignalWPSetting')['app_id'] ?? '';
+    $notification_id = $notice['detail'] ?? '';
+    $dashboard_url   = (!empty($app_id) && !empty($notification_id))
+        ? 'https://dashboard.onesignal.com/apps/' . rawurlencode($app_id) . '/push/' . rawurlencode($notification_id)
+        : '';
+
+    $link = !empty($dashboard_url)
+        ? ' <a href="' . esc_url($dashboard_url) . '" target="_blank" rel="noopener noreferrer">'
+            . esc_html__('View the notification in the OneSignal Dashboard.', 'onesignal')
+            . '</a>'
+        : '';
+
+    switch ($notice['status']) {
+        case 'success':
+            $message = __('Push notification sent successfully.', 'onesignal') . $link;
+            $type    = 'success';
+            break;
+        case 'scheduled':
+            $scheduled_link = !empty($dashboard_url)
+                ? ' <a href="' . esc_url($dashboard_url) . '" target="_blank" rel="noopener noreferrer">'
+                    . esc_html__('View the scheduled notification in the OneSignal Dashboard.', 'onesignal')
+                    . '</a>'
+                : '';
+            $message = __('Push notification scheduled.', 'onesignal')
+                . $scheduled_link . ' '
+                . __('If you change the scheduled post time in WordPress, the existing notification will be cancelled and a new one created.', 'onesignal');
+            $type = 'info';
+            break;
+        case 'error':
+        default:
+            $message = sprintf(
+                __('Push notification failed to send: %s', 'onesignal'),
+                esc_html($notification_id)
+            );
+            $type = 'error';
+            break;
+    }
+
+    printf(
+        '<div class="notice notice-%s is-dismissible"><p><strong>OneSignal:</strong> %s</p></div>',
+        esc_attr($type),
+        $message
+    );
+}
+
+/**
+ * AJAX handler that returns and clears the pending notice for the current user.
+ * Used by the block editor JS after a save completes.
+ */
+function onesignal_ajax_get_send_notice()
+{
+    check_ajax_referer('onesignal_notice_nonce', 'nonce');
+    $key = 'onesignal_send_notice_' . get_current_user_id();
+    $notice = get_transient($key);
+    if ($notice) {
+        delete_transient($key);
+        wp_send_json_success($notice);
+    } else {
+        wp_send_json_success(null);
+    }
+}
+
+/**
+ * Enqueues the block editor JS that polls for a pending notice after each save.
+ */
+function onesignal_enqueue_block_editor_notice()
+{
+    $script_path = plugin_dir_path(__FILE__) . 'onesignal-block-editor-notice.js';
+    if (!file_exists($script_path)) {
+        return;
+    }
+    wp_enqueue_script(
+        'onesignal-block-editor-notice',
+        plugins_url('onesignal-block-editor-notice.js', __FILE__),
+        array('wp-data', 'wp-notices', 'wp-i18n'),
+        filemtime($script_path),
+        true
+    );
+    wp_localize_script('onesignal-block-editor-notice', 'onesignalNotice', array(
+        'nonce'  => wp_create_nonce('onesignal_notice_nonce'),
+        'ajaxUrl' => admin_url('admin-ajax.php'),
+        'appId'  => get_option('OneSignalWPSetting')['app_id'] ?? '',
+    ));
 }
 
 // Function to schedule notification (called on post status transitions)

--- a/v3/onesignal-notification.php
+++ b/v3/onesignal-notification.php
@@ -199,8 +199,8 @@ function onesignal_display_send_notice()
     global $post;
 
     $screen = get_current_screen();
-    // Only show on post edit screens
-    if (!$screen || !in_array($screen->base, array('post', 'edit'), true)) {
+    // Only show on the single-post edit screen
+    if (!$screen || $screen->base !== 'post') {
         return;
     }
 

--- a/v3/onesignal-notification.php
+++ b/v3/onesignal-notification.php
@@ -179,10 +179,23 @@ function onesignal_store_send_notice($status, $detail = '', $post_id = 0)
 }
 
 /**
+ * Builds a dashboard link anchor tag for use in admin notices.
+ */
+function onesignal_build_dashboard_link($url, $label)
+{
+    if (empty($url)) return '';
+    return ' <a href="' . esc_url($url) . '" target="_blank" rel="noopener noreferrer">'
+        . esc_html__($label, 'onesignal')
+        . '</a>';
+}
+
+/**
  * Reads the stored transient and renders a WP admin notice, then deletes it.
  */
 function onesignal_display_send_notice()
 {
+    if (!is_admin()) return;
+
     global $post;
 
     $screen = get_current_screen();
@@ -206,38 +219,29 @@ function onesignal_display_send_notice()
     }
     delete_transient($key);
 
-    $app_id          = get_option('OneSignalWPSetting')['app_id'] ?? '';
-    $notification_id = $notice['detail'] ?? '';
-    $dashboard_url   = (!empty($app_id) && !empty($notification_id))
-        ? 'https://dashboard.onesignal.com/apps/' . rawurlencode($app_id) . '/push/' . rawurlencode($notification_id)
-        : '';
-
-    $link = !empty($dashboard_url)
-        ? ' <a href="' . esc_url($dashboard_url) . '" target="_blank" rel="noopener noreferrer">'
-            . esc_html__('View the notification in the OneSignal Dashboard.', 'onesignal')
-            . '</a>'
+    $app_id = get_option('OneSignalWPSetting')['app_id'] ?? '';
+    $detail = $notice['detail'] ?? '';
+    $dashboard_url = (!empty($app_id) && !empty($detail))
+        ? 'https://dashboard.onesignal.com/apps/' . rawurlencode($app_id) . '/push/' . rawurlencode($detail)
         : '';
 
     switch ($notice['status']) {
         case 'success':
+            $link    = onesignal_build_dashboard_link($dashboard_url, 'View the notification in the OneSignal Dashboard.');
             $message = __('Push notification sent successfully.', 'onesignal') . $link;
             $type    = 'success';
             break;
         case 'scheduled':
-            $scheduled_link = !empty($dashboard_url)
-                ? ' <a href="' . esc_url($dashboard_url) . '" target="_blank" rel="noopener noreferrer">'
-                    . esc_html__('View the scheduled notification in the OneSignal Dashboard.', 'onesignal')
-                    . '</a>'
-                : '';
+            $link    = onesignal_build_dashboard_link($dashboard_url, 'View the scheduled notification in the OneSignal Dashboard.');
             $message = __('Push notification scheduled.', 'onesignal')
-                . $scheduled_link . ' '
+                . $link . ' '
                 . __('If you change the scheduled post time in WordPress, the existing notification will be cancelled and a new one created.', 'onesignal');
-            $type = 'info';
+            $type    = 'info';
             break;
         case 'warning':
             $message = sprintf(
                 __('Push notification not sent: %s', 'onesignal'),
-                esc_html($notice['detail'])
+                esc_html($detail)
             );
             $type = 'warning';
             break;
@@ -245,7 +249,7 @@ function onesignal_display_send_notice()
         default:
             $message = sprintf(
                 __('Push notification failed to send: %s', 'onesignal'),
-                esc_html($notification_id)
+                esc_html($detail)
             );
             $type = 'error';
             break;
@@ -266,6 +270,9 @@ function onesignal_ajax_get_send_notice()
 {
     check_ajax_referer('onesignal_notice_nonce', 'nonce');
     $post_id = absint($_POST['post_id'] ?? 0);
+    if (!current_user_can('edit_post', $post_id)) {
+        wp_send_json_success(null);
+    }
     $key = 'onesignal_send_notice_' . get_current_user_id() . '_' . $post_id;
     $notice = get_transient($key);
     if ($notice) {


### PR DESCRIPTION
Add Success / Error notice in Post editor screen for a Notification send.

- Provides visible feedback, as customers mention not knowing if a notification has been sent, scheduled, or failed.
- Links to created notification in the OneSignal dashboard (opens in a new tab).

<img width="1444" height="114" alt="image" src="https://github.com/user-attachments/assets/762e863c-1e27-442b-9bd7-44544477e117" />
<img width="1445" height="127" alt="image" src="https://github.com/user-attachments/assets/bbf11c91-870f-427b-b7ab-4de005a58b91" />
<img width="1448" height="82" alt="image" src="https://github.com/user-attachments/assets/855d332f-8659-4be9-bd96-4d050c1f50b1" />

Related intercom:
https://app.intercom.com/a/inbox/344a89aeac3f033e4dec4370781543b948aece6d/inbox/admin/5709101/conversation/215473037560885?view=List



