### PR TITLE
fix: [SDK-4340] skip enqueueing metabox assets for disallowed post types

### DIFF
--- a/v3/onesignal-metabox/onesignal-metabox.php
+++ b/v3/onesignal-metabox/onesignal-metabox.php
@@ -123,6 +123,10 @@ add_action('admin_print_styles-post-new.php', 'onesignal_meta_files');
 
 function onesignal_meta_files()
 {
+  if (!onesignal_is_post_type_allowed(get_post_type())) {
+    return;
+  }
+
   $cache_buster = ceil(time() / 3600); // updates every hour
   wp_enqueue_script(
     'onesignal_metabox_js',


### PR DESCRIPTION
## One Line Summary
Stop loading the OneSignal metabox JS/CSS on Custom Post Types that aren't enabled in plugin settings, eliminating a Classic Editor console error.

## Motivation
[SDK-4340](https://linear.app/onesignal/issue/SDK-4340/wordpress-gracefully-fail-when-custom-post-type-is-not-added): When viewing a Custom Post Type in the Classic Editor that has **not** been added to "Additional Custom Post Types" in OneSignal settings, a DOM error appeared in the browser console:

> OneSignal: required elements are missing in the DOM.

The metabox PHP (`onesignal_add_metabox`) correctly skipped rendering for disallowed post types, but `onesignal_meta_files` was registered on `admin_print_styles-post.php` / `admin_print_styles-post-new.php` unconditionally, so the metabox JS still loaded and immediately failed its DOM lookup.

## Scope
- **Affected**: `v3/onesignal-metabox/onesignal-metabox.php` — `onesignal_meta_files()` now early-returns for disallowed post types using the existing `onesignal_is_post_type_allowed()` helper (the same gate already used by `onesignal_add_metabox()`).
- **Not affected**: Posts, Pages (when enabled), and any Custom Post Type listed in "Additional Custom Post Types" continue to load the metabox and its assets exactly as before. No change to v2.

## Testing

### Manual
1. Leave "Additional Custom Post Types" empty in OneSignal settings.
2. Register a CPT (e.g. `product`) and open one in the Classic Editor.
   - Before: console error `OneSignal: required elements are missing in the DOM.`
   - After: no console error, no metabox (expected).
3. Add `product` to "Additional Custom Post Types", reload the edit screen.
   - Metabox renders and behaves as before (segment dropdown, customize content, mobile URL).
4. Verify Posts and Pages still render the metabox and JS as before.

### Unit / Integration
- `composer test` — all 69 existing tests pass.

## Affected code checklist
- [x] PHP plugin code (`v3/`)
- [ ] v2 legacy code
- [ ] JS / CSS assets
- [ ] Build / CI
- [ ] Tests

## Checklist
- [x] Code follows existing style in this file
- [x] Tested manually in Classic Editor with both allowed and disallowed CPTs
- [x] No new lint errors introduced
- [x] Linear ticket linked