### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,64 @@
+<!--
+  Thanks for contributing! Fill out the sections below to help reviewers
+  understand the change. Delete sections that don't apply.
+-->
+
+## One Line Summary
+
+<!-- A single sentence describing what this PR does. -->
+
+## Motivation
+
+<!--
+  Why is this change being made? Link the Linear ticket and/or GitHub issue.
+  Example: SDK-1234, Fixes #123
+-->
+
+## Scope
+
+<!--
+  What is and isn't affected by this PR.
+-->
+
+- **Affected**:
+- **Not affected**:
+
+## Testing
+
+### Manual
+
+<!--
+  Step-by-step manual test plan. Include the editor (Classic / Block),
+  WordPress version, and any relevant plugin settings.
+-->
+
+1.
+2.
+
+### Unit / Integration
+
+<!--
+  Results from `composer test` (or the relevant suite). Note any new tests
+  added.
+-->
+
+- [ ] `composer test` passes locally
+
+## Affected code checklist
+
+- [ ] PHP plugin code (`v3/`)
+- [ ] `v2/` legacy code
+- [ ] JS / CSS assets
+- [ ] Build / CI
+- [ ] Tests
+- [ ] Documentation (README, `readme.txt`, etc.)
+
+## Checklist
+
+- [ ] Code follows existing style in the touched files
+- [ ] Tested manually in the relevant editor(s)
+  - [ ] Gutenberg/Block editor
+  - [ ] Classic editor
+- [ ] No new lint or test errors introduced
+- [ ] Linear ticket / GitHub issue linked above
+- [ ] `readme.txt` and plugin version bumped if user-facing (release PRs only)


### PR DESCRIPTION
## One Line Summary
Add `.github/pull_request_template.md` so new PRs come pre-populated with the sections we already write by hand.

## Motivation
Recent PRs (e.g. #418) have followed a consistent structure — One Line Summary, Motivation with Linear link, Scope, Testing, Affected code checklist. Codifying that as the GitHub PR template removes the cognitive load of remembering the format and gives external contributors a clear pattern to follow.

## Scope
- **Affected**: `.github/pull_request_template.md` (new file). GitHub will use it as the default PR body for new PRs in this repo.
- **Not affected**: Existing open PRs, plugin code, CI.

## Testing
- Rendered the template locally; sections render as expected.
- No code changes, so no unit/integration test impact.

## Affected code checklist
- [ ] PHP plugin code (`v3/`)
- [ ] v2 legacy code
- [ ] JS / CSS assets
- [ ] Build / CI
- [ ] Tests
- [x] Documentation (PR template)

## Checklist
- [x] Markdown renders correctly
- [x] Template captures the sections we already use