### PR TITLE
ci: grant pull-requests:write to Release (v2) and (v3) workflows

### DIFF
--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   prep:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   prep:


### PR DESCRIPTION
## One Line Summary

Add `pull-requests: write` to both the `Release (v3)` and `Release (v2)` workflows so the reusable `create_release` job can open the release PR.

## Motivation

The most recent `Release (v3)` run (for v3.9.0) failed at the `release / create_release` step with:

```
pull request create failed: GraphQL: Resource not accessible by integration (createPullRequest)
##[error]Process completed with exit code 1.
```

The job log shows the token reached the job with only:

```
GITHUB_TOKEN Permissions
  Contents: write
  Metadata: read
```

That job invokes `OneSignal/sdk-shared/.github/workflows/create-release.yml@main`, which calls `gh pr create`. A reusable workflow can only ever narrow — never expand — the caller's permissions, so the lack of `pull-requests: write` on the caller (`.github/workflows/release.yml`) prevents the reusable workflow from creating the release PR.

`release-v2.yml` has the identical structural issue (same reusable workflow, same missing permission), so a future `Release (v2)` dispatch would fail with the same error. Patched in lockstep, matching the convention established by #420 and #421.

Companion to #420, which fixed the analogous permissions/token issue for the `prep / prepare_release` job in both workflows but did not add `pull-requests: write`.

## Scope

- **Affected**: `.github/workflows/release.yml` (`Release (v3)`) and `.github/workflows/release-v2.yml` (`Release (v2)`). All jobs in both pipelines now run with `pull-requests: write`. Only the `release` job needs it for `gh pr create`; the others are unaffected by the broader scope.
- **Not affected**: Runtime plugin code, the reusable workflow in `sdk-shared`, any other workflow in this repo.

## Testing

### Manual

1. Merge this PR.
2. Run `Actions → Release (v3) → Run workflow` against `main` with `version: 3.9.0` (the in-flight release).
3. Confirm the `release / create_release` job no longer errors at `gh pr create` and that PR `chore: Release 3.9.0` is created/updated against `main`.
4. (Next v2 release) Same verification against `release-v2.yml` when the next v2 patch is dispatched.

Note: because `rel/3.9.0` and the `chore(release): v3.9.0` bump commit already exist from the previous failed run, the re-dispatch will rebase the existing branch and run `bump` again. The `sed`-based edits in `bump-version` are idempotent, but the `awk` step that inserts a new `= 3.9.0 =` block into `readme.txt` is not — expect a duplicate changelog entry that may need to be cleaned up on `rel/3.9.0` before the release PR is merged. Will file a follow-up to make `bump-version` idempotent.

### Unit / Integration

- [ ] `composer test` passes locally — N/A, workflow-only change.

## Affected code checklist

- [ ] PHP plugin code (`v3/`)
- [ ] `v2/` legacy code
- [ ] JS / CSS assets
- [x] Build / CI
- [ ] Tests
- [ ] Documentation (README, `readme.txt`, etc.)

## Checklist

- [x] Code follows existing style in the touched files
- [ ] Tested manually in the relevant editor(s) — N/A, CI permissions change
  - [ ] Gutenberg/Block editor
  - [ ] Classic editor
- [x] No new lint or test errors introduced
- [ ] Linear ticket / GitHub issue linked above — no ticket
- [ ] `readme.txt` and plugin version bumped if user-facing (release PRs only) — N/A