### PR TITLE
ci: auto-tag release commits and fix publish-svn permissions

### DIFF
--- a/.github/workflows/publish-svn-v2.yml
+++ b/.github/workflows/publish-svn-v2.yml
@@ -125,6 +125,7 @@ jobs:
     needs: publish
     permissions:
       contents: write
+      pull-requests: read
     uses: OneSignal/sdk-shared/.github/workflows/github-release.yml@main
     with:
       version: ${{ needs.publish.outputs.bare_version }}

--- a/.github/workflows/publish-svn.yml
+++ b/.github/workflows/publish-svn.yml
@@ -96,6 +96,7 @@ jobs:
     needs: publish
     permissions:
       contents: write
+      pull-requests: read
     uses: OneSignal/sdk-shared/.github/workflows/github-release.yml@main
     with:
       version: ${{ needs.publish.outputs.bare_version }}

--- a/.github/workflows/tag-on-release-merge.yml
+++ b/.github/workflows/tag-on-release-merge.yml
@@ -1,0 +1,48 @@
+name: Tag on Release Merge
+
+on:
+  push:
+    branches:
+      - main
+      - v2
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.head_commit.message, 'chore: Release ')
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          # PAT is required so the pushed tag triggers downstream tag-based
+          # workflows (publish-svn.yml / publish-svn-v2.yml). Tags pushed with
+          # the default GITHUB_TOKEN do not trigger other workflows.
+          token: ${{ secrets.GH_PUSH_TOKEN }}
+
+      - uses: onesignal/sdk-shared/.github/actions/setup-git-user@main
+
+      - name: Extract version and push tag
+        env:
+          MSG: ${{ github.event.head_commit.message }}
+        run: |
+          SUBJECT=$(printf '%s\n' "$MSG" | head -n 1)
+
+          # Match: "chore: Release X.Y.Z" or "chore: Release X.Y.Z (#NNN)"
+          VERSION=$(echo "$SUBJECT" | sed -nE 's/^chore: Release ([0-9]+\.[0-9]+\.[0-9]+)( \(#[0-9]+\))?$/\1/p')
+          if [ -z "$VERSION" ]; then
+            echo "Commit subject is not a release commit; skipping: $SUBJECT"
+            exit 0
+          fi
+
+          TAG="v$VERSION"
+          if git rev-parse "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists; skipping."
+            exit 0
+          fi
+
+          echo "Tagging $TAG at $GITHUB_SHA"
+          git tag "$TAG" "$GITHUB_SHA"
+          git push origin "$TAG"


### PR DESCRIPTION
## One Line Summary

Adds a tag-on-merge workflow so the release pipeline runs end-to-end without manual `git tag`, and fixes a `pull-requests` permission bug that was causing `publish-svn.yml` to fail at startup.

## Motivation

The release flow had two gaps that surfaced when shipping v3.9.0:

1. **No automatic tagging after the release PR merges.** `release.yml` (and `release-v2.yml`) only opens the release PR. Nothing pushes the `vX.Y.Z` tag once it merges, so the tag-triggered `publish-svn.yml` workflow never fires, which means no WordPress.org SVN deploy and no GitHub release. For v3.9.0 I had to manually `git tag v3.9.0 <sha> && git push origin v3.9.0` and manually create the GitHub release.
2. **`publish-svn.yml` has a permissions bug.** When I pushed `v3.9.0` to verify the tag-triggered path, `publish-svn.yml` failed at startup with:

   > `Error calling workflow 'OneSignal/sdk-shared/.github/workflows/github-release.yml@main'. The workflow is requesting 'pull-requests: read', but is only allowed 'pull-requests: none'.`

   The shared `github-release.yml` declares `pull-requests: read` (needed by `github.rest.pulls.list()` to look up the release PR body), but the calling `github-release` job in `publish-svn.yml` only granted `contents: write`. Same bug exists in `publish-svn-v2.yml`.

## Scope

- **Affected**:
  - New `.github/workflows/tag-on-release-merge.yml` triggers on push to `main` / `v2`, parses the squash-merge subject for `chore: Release X.Y.Z (#NNN)`, and pushes the `vX.Y.Z` tag using `GH_PUSH_TOKEN` (the default `GITHUB_TOKEN` cannot trigger downstream workflows on tag push).
  - `publish-svn.yml` and `publish-svn-v2.yml`: add `pull-requests: read` to the `github-release` job permissions.
- **Not affected**: plugin source code, `release.yml`, `release-v2.yml`, the SVN deploy logic itself.

## Testing

### Manual

This PR is what the next release would exercise. Validation plan once merged:

1. Confirm `Tag on Release Merge` is listed under Actions.
2. On the next release (e.g. 3.9.1), after the release PR merges into `main`, verify:
   - `Tag on Release Merge` runs and pushes `v3.9.1`.
   - `Publish to WordPress.org (v3 trunk)` triggers from the tag push.
   - Both `publish` and `github-release` jobs complete (the latter previously got `startup_failure`).
   - A GitHub release for `3.9.1` is created automatically.

Local sanity checks on the new workflow:

- Subject regex matches `chore: Release 3.9.0 (#423)` and extracts `3.9.0`.
- Non-matching subjects (e.g. `fix: ...`) are skipped via the job-level `if`.
- Tag creation is idempotent — re-runs against an existing tag exit cleanly.

### Unit / Integration

- N/A — CI workflow changes only, no PHP source touched.
- [x] `composer test` not applicable to this PR

## Affected code checklist

- [ ] PHP plugin code (`v3/`)
- [ ] `v2/` legacy code
- [ ] JS / CSS assets
- [x] Build / CI
- [ ] Tests
- [ ] Documentation (README, `readme.txt`, etc.)

## Checklist

- [x] Code follows existing style in the touched files
- [ ] Tested manually in the relevant editor(s) — N/A
- [x] No new lint or test errors introduced
- [x] Linear ticket / GitHub issue linked above — N/A, infra fix
- [ ] `readme.txt` and plugin version bumped if user-facing — N/A

## Follow-ups (not in this PR)

- The repo does not appear to have `SVN_USERNAME` / `SVN_PASSWORD` secrets at the repo or visible org level. The SVN deploy step in `publish-svn.yml` will still fail on the next release if those aren't configured. Worth confirming whether they live in a restricted org scope.
- v3.9.0 was released manually outside this flow (tag + GitHub release published by hand) before this PR was opened.