### PR TITLE
ci: install subversion in publish-svn workflows

### DIFF
--- a/.github/workflows/publish-svn-v2.yml
+++ b/.github/workflows/publish-svn-v2.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install subversion
+        run: sudo apt-get update && sudo apt-get install -y subversion
+
       - name: Derive versions
         id: version
         run: |

--- a/.github/workflows/publish-svn.yml
+++ b/.github/workflows/publish-svn.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Checkout tagged commit
         uses: actions/checkout@v5
 
+      - name: Install subversion
+        run: sudo apt-get update && sudo apt-get install -y subversion
+
       - name: Strip v prefix from tag
         id: version
         run: echo "bare=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## One Line Summary

Installs `subversion` on the runner before the SVN deploy step, since `ubuntu-latest` no longer ships with `svn` preinstalled.

## Motivation

Follow-up to #424. When re-tagging `v3.9.0` to trigger the now-permission-fixed `publish-svn.yml`, the run got past the reusable-workflow startup check but failed in the `Deploy to SVN trunk` step:

\`\`\`
/home/runner/work/_temp/.../svn: command not found
##[error]Process completed with exit code 127.
\`\`\`

See run: https://github.com/OneSignal/OneSignal-WordPress-Plugin/actions/runs/26300779118

`svn` is no longer a default-installed binary on `ubuntu-latest`; it must be installed explicitly with `apt-get install -y subversion`.

## Scope

- **Affected**: `.github/workflows/publish-svn.yml` and `.github/workflows/publish-svn-v2.yml` — adds an `Install subversion` step right after checkout in both `publish` jobs.
- **Not affected**: plugin source, release workflows, tag-on-merge workflow.

## Testing

### Manual

Validation after merge: re-tag `v3.9.0` at the new fix commit so `publish-svn.yml` runs end-to-end and 3.9.0 lands on WordPress.org trunk + tags.

### Unit / Integration

- N/A — CI workflow change only.

## Affected code checklist

- [ ] PHP plugin code (`v3/`)
- [ ] `v2/` legacy code
- [ ] JS / CSS assets
- [x] Build / CI
- [ ] Tests
- [ ] Documentation

## Checklist

- [x] Code follows existing style in the touched files
- [x] No new lint or test errors introduced