### PR TITLE
ci: update SVN deploy message

### DIFF
--- a/.github/workflows/publish-svn.yml
+++ b/.github/workflows/publish-svn.yml
@@ -82,7 +82,7 @@ jobs:
           # Stage deleted files
           svn status | grep '^\!' | awk '{print $2}' | xargs -r -I {} svn delete "{}"
 
-          svn commit -m "Deploy v${{ steps.version.outputs.bare }} to trunk" \
+          svn commit -m "${{ steps.version.outputs.bare }} release" \
             --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive
 
       - name: Create SVN tag from trunk


### PR DESCRIPTION
<!--
  Thanks for contributing! Fill out the sections below to help reviewers
  understand the change. Delete sections that don't apply.
-->

## One Line Summary

Updates the commit message to be more consistent with past releases. This is what gets displayed on https://plugins.trac.wordpress.org/browser/onesignal-free-web-push-notifications/trunk

## Motivation

Consistency in SVN commit messages

## Scope

<!--
  What is and isn't affected by this PR.
-->

- **Affected**: Publishing update to SVN
- **Not affected**:

## Testing

N/A

## Affected code checklist

- [ ] PHP plugin code (`v3/`)
- [ ] `v2/` legacy code
- [ ] JS / CSS assets
- [ ] Build / CI
- [ ] Tests
- [ ] Documentation (README, `readme.txt`, etc.)

## Checklist

- [ ] Code follows existing style in the touched files
- [ ] Tested manually in the relevant editor(s)
  - [ ] Gutenberg/Block editor
  - [ ] Classic editor
- [ ] No new lint or test errors introduced
- [ ] Linear ticket / GitHub issue linked above
- [ ] `readme.txt` and plugin version bumped if user-facing (release PRs only)
