### PR TITLE
ci: quote if expression in tag-on-release-merge workflow

### DIFF
--- a/.github/workflows/tag-on-release-merge.yml
+++ b/.github/workflows/tag-on-release-merge.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   tag:
     runs-on: ubuntu-latest
-    if: startsWith(github.event.head_commit.message, 'chore: Release ')
+    if: "startsWith(github.event.head_commit.message, 'chore: Release ')"
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
## One Line Summary

Fix invalid YAML in `tag-on-release-merge.yml` that prevented release commits from being auto-tagged (and therefore published).

## Motivation

The `if:` condition on the `tag` job was an unquoted YAML scalar containing `'chore: Release '`. The embedded `: ` (colon-space) was parsed as a YAML mapping separator, producing `mapping values are not allowed in this context at line 15`. A YAML syntax error invalidates the **entire** workflow file, so GitHub refused to load it and the workflow never ran.

Impact: when `chore: Release X.Y.Z` commits merged to `main`, no `vX.Y.Z` tag was created, so the downstream `publish-svn.yml` (triggered on `v3.*` tags) never fired and the release was not published to WordPress.org. This is what happened with `3.9.1` (#428) — the tag was missing and had to be pushed manually to unblock the release.

## Scope

- Only changes the `if:` line in `.github/workflows/tag-on-release-merge.yml`.
- No change to runtime behavior: GitHub Actions evaluates `if:` strings as expressions, so quoting is purely a YAML-parsing fix.
- The same workflow runs for `v2` releases, which this also fixes.

## Testing

- Reproduced the parse error locally (`mapping values are not allowed in this context at line 15 column 60`).
- Verified the quoted form parses cleanly as valid YAML.

## Checklist

- [x] Verified the fix parses as valid YAML
- [x] No behavioral change to the workflow logic