### PR TITLE
fix: create GitHub release against the v-prefixed tag

### DIFF
--- a/.github/workflows/publish-svn-v2.yml
+++ b/.github/workflows/publish-svn-v2.yml
@@ -152,13 +152,18 @@ jobs:
               if (e.status !== 404) throw e;
             }
 
-            const prs = await github.rest.pulls.list({
-              owner, repo, state: 'closed', sort: 'updated', direction: 'desc', per_page: 50,
+            // The tagged commit is the merge commit of the "Release <version>" PR; look it up by
+            // SHA so this is immune to title prefix collisions (2.4.1 vs 2.4.10) and pagination.
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner, repo, commit_sha: context.sha,
             });
-            const releasePr = prs.data.find(pr =>
-              pr.merged_at && pr.title.replace(/^chore:\s*/i, '').startsWith(`Release ${version}`)
-            );
-            const body = releasePr ? releasePr.body.split('<!--')[0].trim() : '';
+            const releasePr =
+              prs.find(pr => pr.merged_at && pr.title.replace(/^chore:\s*/i, '') === `Release ${version}`) ||
+              prs.find(pr => pr.merged_at);
+            if (!releasePr) {
+              core.warning(`No merged release PR found for ${tag}; publishing release with empty notes.`);
+            }
+            const body = releasePr && releasePr.body ? releasePr.body.split('<!--')[0].trim() : '';
 
             await github.rest.repos.createRelease({
               owner, repo,

--- a/.github/workflows/publish-svn-v2.yml
+++ b/.github/workflows/publish-svn-v2.yml
@@ -126,11 +126,45 @@ jobs:
 
   github-release:
     needs: publish
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: read
-    uses: OneSignal/sdk-shared/.github/workflows/github-release.yml@main
-    with:
-      version: ${{ needs.publish.outputs.bare_version }}
-    secrets:
-      GH_PUSH_TOKEN: ${{ secrets.GH_PUSH_TOKEN }}
+    steps:
+      - name: Create GitHub Release
+        uses: actions/github-script@v9
+        env:
+          TAG: ${{ github.ref_name }}
+          VERSION: ${{ needs.publish.outputs.bare_version }}
+        with:
+          github-token: ${{ secrets.GH_PUSH_TOKEN || github.token }}
+          script: |
+            // Tags are v-prefixed (e.g. v2.4.6); releases are titled with the bare version (e.g. 2.4.6).
+            const tag = process.env.TAG;
+            const version = process.env.VERSION;
+            const { owner, repo } = context.repo;
+
+            try {
+              await github.rest.repos.getReleaseByTag({ owner, repo, tag });
+              core.info(`Release for ${tag} already exists; skipping.`);
+              return;
+            } catch (e) {
+              if (e.status !== 404) throw e;
+            }
+
+            const prs = await github.rest.pulls.list({
+              owner, repo, state: 'closed', sort: 'updated', direction: 'desc', per_page: 50,
+            });
+            const releasePr = prs.data.find(pr =>
+              pr.merged_at && pr.title.replace(/^chore:\s*/i, '').startsWith(`Release ${version}`)
+            );
+            const body = releasePr ? releasePr.body.split('<!--')[0].trim() : '';
+
+            await github.rest.repos.createRelease({
+              owner, repo,
+              tag_name: tag,
+              name: version,
+              body,
+              draft: false,
+              prerelease: /alpha|beta/i.test(version),
+            });

--- a/.github/workflows/publish-svn.yml
+++ b/.github/workflows/publish-svn.yml
@@ -97,11 +97,45 @@ jobs:
 
   github-release:
     needs: publish
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: read
-    uses: OneSignal/sdk-shared/.github/workflows/github-release.yml@main
-    with:
-      version: ${{ needs.publish.outputs.bare_version }}
-    secrets:
-      GH_PUSH_TOKEN: ${{ secrets.GH_PUSH_TOKEN }}
+    steps:
+      - name: Create GitHub Release
+        uses: actions/github-script@v9
+        env:
+          TAG: ${{ github.ref_name }}
+          VERSION: ${{ needs.publish.outputs.bare_version }}
+        with:
+          github-token: ${{ secrets.GH_PUSH_TOKEN || github.token }}
+          script: |
+            // Tags are v-prefixed (e.g. v3.9.1); releases are titled with the bare version (e.g. 3.9.1).
+            const tag = process.env.TAG;
+            const version = process.env.VERSION;
+            const { owner, repo } = context.repo;
+
+            try {
+              await github.rest.repos.getReleaseByTag({ owner, repo, tag });
+              core.info(`Release for ${tag} already exists; skipping.`);
+              return;
+            } catch (e) {
+              if (e.status !== 404) throw e;
+            }
+
+            const prs = await github.rest.pulls.list({
+              owner, repo, state: 'closed', sort: 'updated', direction: 'desc', per_page: 50,
+            });
+            const releasePr = prs.data.find(pr =>
+              pr.merged_at && pr.title.replace(/^chore:\s*/i, '').startsWith(`Release ${version}`)
+            );
+            const body = releasePr ? releasePr.body.split('<!--')[0].trim() : '';
+
+            await github.rest.repos.createRelease({
+              owner, repo,
+              tag_name: tag,
+              name: version,
+              body,
+              draft: false,
+              prerelease: /alpha|beta/i.test(version),
+            });

--- a/.github/workflows/publish-svn.yml
+++ b/.github/workflows/publish-svn.yml
@@ -123,13 +123,18 @@ jobs:
               if (e.status !== 404) throw e;
             }
 
-            const prs = await github.rest.pulls.list({
-              owner, repo, state: 'closed', sort: 'updated', direction: 'desc', per_page: 50,
+            // The tagged commit is the merge commit of the "Release <version>" PR; look it up by
+            // SHA so this is immune to title prefix collisions (3.9.1 vs 3.9.10) and pagination.
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner, repo, commit_sha: context.sha,
             });
-            const releasePr = prs.data.find(pr =>
-              pr.merged_at && pr.title.replace(/^chore:\s*/i, '').startsWith(`Release ${version}`)
-            );
-            const body = releasePr ? releasePr.body.split('<!--')[0].trim() : '';
+            const releasePr =
+              prs.find(pr => pr.merged_at && pr.title.replace(/^chore:\s*/i, '') === `Release ${version}`) ||
+              prs.find(pr => pr.merged_at);
+            if (!releasePr) {
+              core.warning(`No merged release PR found for ${tag}; publishing release with empty notes.`);
+            }
+            const body = releasePr && releasePr.body ? releasePr.body.split('<!--')[0].trim() : '';
 
             await github.rest.repos.createRelease({
               owner, repo,


### PR DESCRIPTION
## One Line Summary

Fix the GitHub Release step so it uses the real `v`-prefixed git tag instead of creating a stray bare-version tag.

## Motivation

The publish workflows delegated GitHub Release creation to the shared `OneSignal/sdk-shared/.github/workflows/github-release.yml`, which uses a single `version` value for **both** the release `name` and the git `tag_name`:

```js
await github.rest.repos.createRelease({ tag_name: version, name: version, ... })
```

This repo passed the **bare** version (e.g. `3.9.1`, with the `v` stripped), but our tags are **v-prefixed** (`v3.9.1`). So `createRelease({ tag_name: "3.9.1" })` would target a tag that doesn't exist and create a brand-new lightweight `3.9.1` tag off the default branch — inconsistent with the `v3.9.1` convention and disconnected from the published commit. The shared workflow assumes `tag == name == version` (bare tags), which doesn't hold for this repo.

This is also why the 3.9.1 GitHub Release had to be created manually after the release pipeline ran.

## Scope

- Replaces the shared-workflow `github-release` job in both `publish-svn.yml` (v3) and `publish-svn-v2.yml` (v2) with an inline `actions/github-script` job.
- The release is now tagged with `github.ref_name` (the actual `v`-prefixed tag that triggered the publish) and titled with the bare version, matching existing releases (`v3.9.0` tag / `3.9.0` title).
- Preserves the existing behavior of sourcing release notes from the merged `Release <version>` PR body.
- Adds an idempotency guard: if a release for the tag already exists, the job logs and skips instead of failing.
- No change to the SVN publish jobs.

## Testing

- Both workflow files validated as parseable YAML.
- The embedded `github-script` body passes `node --check` and runs end-to-end against mocked `github`/`context`/`core` objects.

## Notes

- This intentionally stops using the shared `github-release.yml` for these two workflows because that workflow cannot express a `tag_name` that differs from the release `name`. An alternative would be to add an optional `tag_name` input to the shared workflow; that's a broader, cross-SDK change and can be done separately if preferred.
- The 403 "Resource not accessible by personal access token" failure seen on the 3.9.1 run is a **separate** issue with the `GH_PUSH_TOKEN` org secret and is being addressed independently.

## Checklist

- [x] Both workflows parse as valid YAML
- [x] `github-script` body syntax-checked and smoke-tested
- [x] Release now uses the v-prefixed tag; title stays bare